### PR TITLE
NEW feature: shmem_pmi

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -120,3 +120,49 @@ the Free Software Foundation.  You should have received a copy of the
 GNU General Public License along with this program; if not, write to the
 Free Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
+======================================================================
+
+	SHMEM-PMI implementation is derived from MPICH
+
+
+  COPYRIGHT
+
+The following is a notice of limited availability of the code, and disclaimer
+which must be included in the prologue of the code and in all source listings
+of the code.
+
+Copyright Notice
++ 2002 University of Chicago
+
+Permission is hereby granted to use, reproduce, prepare derivative works, and
+to redistribute to others.  This software was authored by:
+
+Mathematics and Computer Science Division
+Argonne National Laboratory, Argonne IL 60439
+
+(and)
+
+Department of Computer Science
+University of Illinois at Urbana-Champaign
+
+
+                             GOVERNMENT LICENSE
+
+Portions of this material resulted from work developed under a U.S.
+Government Contract and are subject to the following license: the Government
+is granted for itself and others acting on its behalf a paid-up, nonexclusive,
+irrevocable worldwide license in this computer software to reproduce, prepare
+derivative works, and perform publicly and display publicly.
+
+                                 DISCLAIMER
+
+This computer code material was prepared, in part, as an account of work
+sponsored by an agency of the United States Government.  Neither the United
+States, nor the University of Chicago, nor any of their employees, makes any
+warranty express or implied, or assumes any legal liability or responsibility
+for the accuracy, completeness, or usefulness of any information, apparatus,
+product, or process disclosed, or represents that its use would not infringe
+privately owned rights.
+
+======================================================================
+

--- a/config/ompi_check_ofi.m4
+++ b/config/ompi_check_ofi.m4
@@ -66,7 +66,7 @@ AC_DEFUN([OMPI_CHECK_OFI],[
 
     AS_IF([test "$ompi_check_ofi_happy" = "yes"],
 	  [AS_IF([test "$enable_remote_virtual_addressing" = "yes"],
-		[ompi_check_ofi_happy = "yes" ],
+		[ompi_check_ofi_happy="yes"],
 		[AC_MSG_ERROR([OFI transport requires remote VA enabled. Please use --enable-remote-virtual-addressing. Aborting])])])
 
     AS_IF([test "$ompi_check_ofi_happy" = "yes"],

--- a/configure.ac
+++ b/configure.ac
@@ -113,7 +113,6 @@ AC_ARG_ENABLE([profiling],
                     [Enable shmem call profiling (default:disabled)])])
 AS_IF([test "$enable_profiling" = "yes"], [AC_DEFINE([ENABLE_PROFILING], [1], [Enable shmem call profiling])])
 
-
 dnl check for programs
 
 AC_PROG_CC
@@ -368,7 +367,7 @@ echo "  Fortran:        $FORT"
 echo ""
 echo "Transports:"
 echo "  Portals 4:      $transport_portals4"
-echo "  OFI:      	$transport_ofi"
+echo "  OFI:            $transport_ofi"
 echo "  XPMEM:          $transport_xpmem"
 echo "  CMA:            $transport_cma"
 echo ""

--- a/shmem_pmi/Makefile.am
+++ b/shmem_pmi/Makefile.am
@@ -10,5 +10,4 @@ libshmem_pmi_la_SOURCES = \
 
 install-exec-hook:
 	$(MKDIR_P) ../install/lib
-	$(LN_S) $(DESTDIR)$(libdir)/libshmem_pmi.so ../install/lib/libshmem_pmi.so
-	$(LN_S) $(DESTDIR)$(libdir)/libshmem_pmi.so.0 ../install/lib/libshmem_pmi.so.0
+	$(LN_S) -f $(DESTDIR)$(libdir)/libshmem_pmi${shrext_cmds} ../install/lib/libshmem_pmi${shrext_cmds}

--- a/shmem_pmi/Makefile.am
+++ b/shmem_pmi/Makefile.am
@@ -1,0 +1,14 @@
+
+AM_CPPFLAGS= -I$(top_srcdir)/shmem_pmi
+
+lib_LTLIBRARIES = libshmem_pmi.la
+libshmem_pmi_la_SOURCES = \
+	simple_pmi.c \
+	simple_pmiutil.c \
+	simple_pmiutil.h \
+	pmi.h
+
+install-exec-hook:
+	$(MKDIR_P) ../install/lib
+	$(LN_S) $(DESTDIR)$(libdir)/libshmem_pmi.so ../install/lib/libshmem_pmi.so
+	$(LN_S) $(DESTDIR)$(libdir)/libshmem_pmi.so.0 ../install/lib/libshmem_pmi.so.0

--- a/shmem_pmi/autogen.sh
+++ b/shmem_pmi/autogen.sh
@@ -1,0 +1,9 @@
+#! /bin/sh
+
+set -x
+test -d ./config || mkdir ./config
+aclocal -I config
+libtoolize --force --copy
+autoheader
+automake --foreign --add-missing --copy
+autoconf

--- a/shmem_pmi/configure.ac
+++ b/shmem_pmi/configure.ac
@@ -1,0 +1,10 @@
+AC_INIT([shmem_pmi], [1.0], [kayla.seager@intel.com])
+AC_CONFIG_AUX_DIR([config])
+AC_CONFIG_MACRO_DIR([config])
+AM_INIT_AUTOMAKE
+AC_CONFIG_HEADERS([config.h])
+AC_PROG_CC
+m4_ifdef([AM_PROG_AR],[AM_PROG_AR])
+LT_INIT
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/shmem_pmi/configure.ac
+++ b/shmem_pmi/configure.ac
@@ -1,6 +1,7 @@
 AC_INIT([shmem_pmi], [1.0], [kayla.seager@intel.com])
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([config])
+AC_SUBST(shrext_cmds)
 AM_INIT_AUTOMAKE
 AC_CONFIG_HEADERS([config.h])
 AC_PROG_CC

--- a/shmem_pmi/include/pmi.h
+++ b/shmem_pmi/include/pmi.h
@@ -1,0 +1,473 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2001 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#ifndef PMI_H_INCLUDED
+#define PMI_H_INCLUDED
+
+#ifdef USE_PMI2_API
+#error This header file defines the PMI v1 API, but PMI2 was selected
+#endif
+
+/* prototypes for the PMI interface in MPICH */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*D
+PMI_CONSTANTS - PMI definitions
+
+Error Codes:
++ PMI_SUCCESS - operation completed successfully
+. PMI_FAIL - operation failed
+. PMI_ERR_NOMEM - input buffer not large enough
+. PMI_ERR_INIT - PMI not initialized
+. PMI_ERR_INVALID_ARG - invalid argument
+. PMI_ERR_INVALID_KEY - invalid key argument
+. PMI_ERR_INVALID_KEY_LENGTH - invalid key length argument
+. PMI_ERR_INVALID_VAL - invalid val argument
+. PMI_ERR_INVALID_VAL_LENGTH - invalid val length argument
+. PMI_ERR_INVALID_LENGTH - invalid length argument
+. PMI_ERR_INVALID_NUM_ARGS - invalid number of arguments
+. PMI_ERR_INVALID_ARGS - invalid args argument
+. PMI_ERR_INVALID_NUM_PARSED - invalid num_parsed length argument
+. PMI_ERR_INVALID_KEYVALP - invalid keyvalp argument
+- PMI_ERR_INVALID_SIZE - invalid size argument
+
+Booleans:
++ PMI_TRUE - true
+- PMI_FALSE - false
+
+D*/
+#define PMI_SUCCESS                  0
+#define PMI_FAIL                    -1
+#define PMI_ERR_INIT                 1
+#define PMI_ERR_NOMEM                2
+#define PMI_ERR_INVALID_ARG          3
+#define PMI_ERR_INVALID_KEY          4
+#define PMI_ERR_INVALID_KEY_LENGTH   5
+#define PMI_ERR_INVALID_VAL          6
+#define PMI_ERR_INVALID_VAL_LENGTH   7
+#define PMI_ERR_INVALID_LENGTH       8
+#define PMI_ERR_INVALID_NUM_ARGS     9
+#define PMI_ERR_INVALID_ARGS        10
+#define PMI_ERR_INVALID_NUM_PARSED  11
+#define PMI_ERR_INVALID_KEYVALP     12
+#define PMI_ERR_INVALID_SIZE        13
+
+/* PMI Group functions */
+
+/*@
+PMI_Init - initialize the Process Manager Interface
+
+Output Parameter:
+. spawned - spawned flag
+
+Return values:
++ PMI_SUCCESS - initialization completed successfully
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - initialization failed
+
+Notes:
+Initialize PMI for this process group. The value of spawned indicates whether
+this process was created by 'PMI_Spawn_multiple'.  'spawned' will be 'PMI_TRUE' if
+this process group has a parent and 'PMI_FALSE' if it does not.
+
+@*/
+int PMI_Init( int *spawned );
+
+/*@
+PMI_Initialized - check if PMI has been initialized
+
+Output Parameter:
+. initialized - boolean value
+
+Return values:
++ PMI_SUCCESS - initialized successfully set
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to set the variable
+
+Notes:
+On successful output, initialized will either be 'PMI_TRUE' or 'PMI_FALSE'.
+
++ PMI_TRUE - initialize has been called.
+- PMI_FALSE - initialize has not been called or previously failed.
+
+@*/
+int PMI_Initialized( int *initialized );
+
+/*@
+PMI_Finalize - finalize the Process Manager Interface
+
+Return values:
++ PMI_SUCCESS - finalization completed successfully
+- PMI_FAIL - finalization failed
+
+Notes:
+ Finalize PMI for this process group.
+
+@*/
+int PMI_Finalize( void );
+
+/*@
+PMI_Get_size - obtain the size of the process group
+
+Output Parameters:
+. size - pointer to an integer that receives the size of the process group
+
+Return values:
++ PMI_SUCCESS - size successfully obtained
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to return the size
+
+Notes:
+This function returns the size of the process group to which the local process
+belongs.
+
+@*/
+int PMI_Get_size( int *size );
+
+/*@
+PMI_Get_rank - obtain the rank of the local process in the process group
+
+Output Parameters:
+. rank - pointer to an integer that receives the rank in the process group
+
+Return values:
++ PMI_SUCCESS - rank successfully obtained
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to return the rank
+
+Notes:
+This function returns the rank of the local process in its process group.
+
+@*/
+int PMI_Get_rank( int *rank );
+
+/*@
+PMI_Get_universe_size - obtain the universe size
+
+Output Parameters:
+. size - pointer to an integer that receives the size
+
+Return values:
++ PMI_SUCCESS - size successfully obtained
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to return the size
+
+
+@*/
+int PMI_Get_universe_size( int *size );
+
+/*@
+PMI_Get_appnum - obtain the application number
+
+Output parameters:
+. appnum - pointer to an integer that receives the appnum
+
+Return values:
++ PMI_SUCCESS - appnum successfully obtained
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to return the size
+
+
+@*/
+int PMI_Get_appnum( int *appnum );
+
+/*@
+PMI_Publish_name - publish a name
+
+Input parameters:
+. service_name - string representing the service being published
+. port - string representing the port on which to contact the service
+
+Return values:
++ PMI_SUCCESS - port for service successfully published
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to publish service
+
+
+@*/
+int PMI_Publish_name( const char service_name[], const char port[] );
+
+/*@
+PMI_Unpublish_name - unpublish a name
+
+Input parameters:
+. service_name - string representing the service being unpublished
+
+Return values:
++ PMI_SUCCESS - port for service successfully published
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to unpublish service
+
+
+@*/
+int PMI_Unpublish_name( const char service_name[] );
+
+/*@
+PMI_Lookup_name - lookup a service by name
+
+Input parameters:
+. service_name - string representing the service being published
+
+Output parameters:
+. port - string representing the port on which to contact the service
+
+Return values:
++ PMI_SUCCESS - port for service successfully obtained
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to lookup service
+
+
+@*/
+int PMI_Lookup_name( const char service_name[], char port[] );
+
+/*@
+PMI_Barrier - barrier across the process group
+
+Return values:
++ PMI_SUCCESS - barrier successfully finished
+- PMI_FAIL - barrier failed
+
+Notes:
+This function is a collective call across all processes in the process group
+the local process belongs to.  It will not return until all the processes
+have called 'PMI_Barrier()'.
+
+@*/
+int PMI_Barrier( void );
+
+/*@
+PMI_Abort - abort the process group associated with this process
+
+Input Parameters:
++ exit_code - exit code to be returned by this process
+- error_msg - error message to be printed
+
+Return values:
+. none - this function should not return
+@*/
+int PMI_Abort(int exit_code, const char error_msg[]);
+
+/* PMI Keymap functions */
+/*@
+PMI_KVS_Get_my_name - obtain the name of the keyval space the local process group has access to
+
+Input Parameters:
+. length - length of the kvsname character array
+
+Output Parameters:
+. kvsname - a string that receives the keyval space name
+
+Return values:
++ PMI_SUCCESS - kvsname successfully obtained
+. PMI_ERR_INVALID_ARG - invalid argument
+. PMI_ERR_INVALID_LENGTH - invalid length argument
+- PMI_FAIL - unable to return the kvsname
+
+Notes:
+This function returns the name of the keyval space that this process and all
+other processes in the process group have access to.  The output parameter,
+kvsname, must be at least as long as the value returned by
+'PMI_KVS_Get_name_length_max()'.
+
+@*/
+int PMI_KVS_Get_my_name( char kvsname[], int length );
+
+/*@
+PMI_KVS_Get_name_length_max - obtain the length necessary to store a kvsname
+
+Output Parameter:
+. length - maximum length required to hold a keyval space name
+
+Return values:
++ PMI_SUCCESS - length successfully set
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to set the length
+
+Notes:
+This function returns the string length required to store a keyval space name.
+
+A routine is used rather than setting a maximum value in 'pmi.h' to allow
+different implementations of PMI to be used with the same executable.  These
+different implementations may allow different maximum lengths; by using a
+routine here, we can interface with a variety of implementations of PMI.
+
+@*/
+int PMI_KVS_Get_name_length_max( int *length );
+
+/*@
+PMI_KVS_Get_key_length_max - obtain the length necessary to store a key
+
+Output Parameter:
+. length - maximum length required to hold a key string.
+
+Return values:
++ PMI_SUCCESS - length successfully set
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to set the length
+
+Notes:
+This function returns the string length required to store a key.
+
+@*/
+int PMI_KVS_Get_key_length_max( int *length );
+
+/*@
+PMI_KVS_Get_value_length_max - obtain the length necessary to store a value
+
+Output Parameter:
+. length - maximum length required to hold a keyval space value
+
+Return values:
++ PMI_SUCCESS - length successfully set
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to set the length
+
+Notes:
+This function returns the string length required to store a value from a
+keyval space.
+
+@*/
+int PMI_KVS_Get_value_length_max( int *length );
+
+/*@
+PMI_KVS_Put - put a key/value pair in a keyval space
+
+Input Parameters:
++ kvsname - keyval space name
+. key - key
+- value - value
+
+Return values:
++ PMI_SUCCESS - keyval pair successfully put in keyval space
+. PMI_ERR_INVALID_KVS - invalid kvsname argument
+. PMI_ERR_INVALID_KEY - invalid key argument
+. PMI_ERR_INVALID_VAL - invalid val argument
+- PMI_FAIL - put failed
+
+Notes:
+This function puts the key/value pair in the specified keyval space.  The
+value is not visible to other processes until 'PMI_KVS_Commit()' is called.
+The function may complete locally.  After 'PMI_KVS_Commit()' is called, the
+value may be retrieved by calling 'PMI_KVS_Get()'.  All keys put to a keyval
+space must be unique to the keyval space.  You may not put more than once
+with the same key.
+
+@*/
+int PMI_KVS_Put( const char kvsname[], const char key[], const char value[]);
+
+/*@
+PMI_KVS_Commit - commit all previous puts to the keyval space
+
+Input Parameters:
+. kvsname - keyval space name
+
+Return values:
++ PMI_SUCCESS - commit succeeded
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - commit failed
+
+Notes:
+This function commits all previous puts since the last 'PMI_KVS_Commit()' into
+the specified keyval space. It is a process local operation.
+
+@*/
+int PMI_KVS_Commit( const char kvsname[] );
+
+/*@
+PMI_KVS_Get - get a key/value pair from a keyval space
+
+Input Parameters:
++ kvsname - keyval space name
+. key - key
+- length - length of value character array
+
+Output Parameters:
+. value - value
+
+Return values:
++ PMI_SUCCESS - get succeeded
+. PMI_ERR_INVALID_KVS - invalid kvsname argument
+. PMI_ERR_INVALID_KEY - invalid key argument
+. PMI_ERR_INVALID_VAL - invalid val argument
+. PMI_ERR_INVALID_LENGTH - invalid length argument
+- PMI_FAIL - get failed
+
+Notes:
+This function gets the value of the specified key in the keyval space.
+
+@*/
+int PMI_KVS_Get( const char kvsname[], const char key[], char value[], int length);
+
+/* PMI Process Creation functions */
+
+/*S
+PMI_keyval_t - keyval structure used by PMI_Spawn_mulitiple
+
+Fields:
++ key - name of the key
+- val - value of the key
+
+S*/
+typedef struct PMI_keyval_t
+{
+    const char * key;
+    char * val;
+} PMI_keyval_t;
+
+/*@
+PMI_Spawn_multiple - spawn a new set of processes
+
+Input Parameters:
++ count - count of commands
+. cmds - array of command strings
+. argvs - array of argv arrays for each command string
+. maxprocs - array of maximum processes to spawn for each command string
+. info_keyval_sizes - array giving the number of elements in each of the
+  'info_keyval_vectors'
+. info_keyval_vectors - array of keyval vector arrays
+. preput_keyval_size - Number of elements in 'preput_keyval_vector'
+- preput_keyval_vector - array of keyvals to be pre-put in the spawned keyval space
+
+Output Parameter:
+. errors - array of errors for each command
+
+Return values:
++ PMI_SUCCESS - spawn successful
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - spawn failed
+
+Notes:
+This function spawns a set of processes into a new process group.  The 'count'
+field refers to the size of the array parameters - 'cmd', 'argvs', 'maxprocs',
+'info_keyval_sizes' and 'info_keyval_vectors'.  The 'preput_keyval_size' refers
+to the size of the 'preput_keyval_vector' array.  The 'preput_keyval_vector'
+contains keyval pairs that will be put in the keyval space of the newly
+created process group before the processes are started.  The 'maxprocs' array
+specifies the desired number of processes to create for each 'cmd' string.
+The actual number of processes may be less than the numbers specified in
+maxprocs.  The acceptable number of processes spawned may be controlled by
+``soft'' keyvals in the info arrays.  The ``soft'' option is specified by
+mpiexec in the MPI-2 standard.  Environment variables may be passed to the
+spawned processes through PMI implementation specific 'info_keyval' parameters.
+@*/
+int PMI_Spawn_multiple(int count,
+                       const char * cmds[],
+                       const char ** argvs[],
+                       const int maxprocs[],
+                       const int info_keyval_sizesp[],
+                       const PMI_keyval_t * info_keyval_vectors[],
+                       int preput_keyval_size,
+                       const PMI_keyval_t preput_keyval_vector[],
+                       int errors[]);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/shmem_pmi/pmi.h
+++ b/shmem_pmi/pmi.h
@@ -1,0 +1,473 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2001 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#ifndef PMI_H_INCLUDED
+#define PMI_H_INCLUDED
+
+#ifdef USE_PMI2_API
+#error This header file defines the PMI v1 API, but PMI2 was selected
+#endif
+
+/* prototypes for the PMI interface in MPICH */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*D
+PMI_CONSTANTS - PMI definitions
+
+Error Codes:
++ PMI_SUCCESS - operation completed successfully
+. PMI_FAIL - operation failed
+. PMI_ERR_NOMEM - input buffer not large enough
+. PMI_ERR_INIT - PMI not initialized
+. PMI_ERR_INVALID_ARG - invalid argument
+. PMI_ERR_INVALID_KEY - invalid key argument
+. PMI_ERR_INVALID_KEY_LENGTH - invalid key length argument
+. PMI_ERR_INVALID_VAL - invalid val argument
+. PMI_ERR_INVALID_VAL_LENGTH - invalid val length argument
+. PMI_ERR_INVALID_LENGTH - invalid length argument
+. PMI_ERR_INVALID_NUM_ARGS - invalid number of arguments
+. PMI_ERR_INVALID_ARGS - invalid args argument
+. PMI_ERR_INVALID_NUM_PARSED - invalid num_parsed length argument
+. PMI_ERR_INVALID_KEYVALP - invalid keyvalp argument
+- PMI_ERR_INVALID_SIZE - invalid size argument
+
+Booleans:
++ PMI_TRUE - true
+- PMI_FALSE - false
+
+D*/
+#define PMI_SUCCESS                  0
+#define PMI_FAIL                    -1
+#define PMI_ERR_INIT                 1
+#define PMI_ERR_NOMEM                2
+#define PMI_ERR_INVALID_ARG          3
+#define PMI_ERR_INVALID_KEY          4
+#define PMI_ERR_INVALID_KEY_LENGTH   5
+#define PMI_ERR_INVALID_VAL          6
+#define PMI_ERR_INVALID_VAL_LENGTH   7
+#define PMI_ERR_INVALID_LENGTH       8
+#define PMI_ERR_INVALID_NUM_ARGS     9
+#define PMI_ERR_INVALID_ARGS        10
+#define PMI_ERR_INVALID_NUM_PARSED  11
+#define PMI_ERR_INVALID_KEYVALP     12
+#define PMI_ERR_INVALID_SIZE        13
+
+/* PMI Group functions */
+
+/*@
+PMI_Init - initialize the Process Manager Interface
+
+Output Parameter:
+. spawned - spawned flag
+
+Return values:
++ PMI_SUCCESS - initialization completed successfully
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - initialization failed
+
+Notes:
+Initialize PMI for this process group. The value of spawned indicates whether
+this process was created by 'PMI_Spawn_multiple'.  'spawned' will be 'PMI_TRUE' if
+this process group has a parent and 'PMI_FALSE' if it does not.
+
+@*/
+int PMI_Init( int *spawned );
+
+/*@
+PMI_Initialized - check if PMI has been initialized
+
+Output Parameter:
+. initialized - boolean value
+
+Return values:
++ PMI_SUCCESS - initialized successfully set
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to set the variable
+
+Notes:
+On successful output, initialized will either be 'PMI_TRUE' or 'PMI_FALSE'.
+
++ PMI_TRUE - initialize has been called.
+- PMI_FALSE - initialize has not been called or previously failed.
+
+@*/
+int PMI_Initialized( int *initialized );
+
+/*@
+PMI_Finalize - finalize the Process Manager Interface
+
+Return values:
++ PMI_SUCCESS - finalization completed successfully
+- PMI_FAIL - finalization failed
+
+Notes:
+ Finalize PMI for this process group.
+
+@*/
+int PMI_Finalize( void );
+
+/*@
+PMI_Get_size - obtain the size of the process group
+
+Output Parameters:
+. size - pointer to an integer that receives the size of the process group
+
+Return values:
++ PMI_SUCCESS - size successfully obtained
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to return the size
+
+Notes:
+This function returns the size of the process group to which the local process
+belongs.
+
+@*/
+int PMI_Get_size( int *size );
+
+/*@
+PMI_Get_rank - obtain the rank of the local process in the process group
+
+Output Parameters:
+. rank - pointer to an integer that receives the rank in the process group
+
+Return values:
++ PMI_SUCCESS - rank successfully obtained
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to return the rank
+
+Notes:
+This function returns the rank of the local process in its process group.
+
+@*/
+int PMI_Get_rank( int *rank );
+
+/*@
+PMI_Get_universe_size - obtain the universe size
+
+Output Parameters:
+. size - pointer to an integer that receives the size
+
+Return values:
++ PMI_SUCCESS - size successfully obtained
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to return the size
+
+
+@*/
+int PMI_Get_universe_size( int *size );
+
+/*@
+PMI_Get_appnum - obtain the application number
+
+Output parameters:
+. appnum - pointer to an integer that receives the appnum
+
+Return values:
++ PMI_SUCCESS - appnum successfully obtained
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to return the size
+
+
+@*/
+int PMI_Get_appnum( int *appnum );
+
+/*@
+PMI_Publish_name - publish a name
+
+Input parameters:
+. service_name - string representing the service being published
+. port - string representing the port on which to contact the service
+
+Return values:
++ PMI_SUCCESS - port for service successfully published
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to publish service
+
+
+@*/
+int PMI_Publish_name( const char service_name[], const char port[] );
+
+/*@
+PMI_Unpublish_name - unpublish a name
+
+Input parameters:
+. service_name - string representing the service being unpublished
+
+Return values:
++ PMI_SUCCESS - port for service successfully published
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to unpublish service
+
+
+@*/
+int PMI_Unpublish_name( const char service_name[] );
+
+/*@
+PMI_Lookup_name - lookup a service by name
+
+Input parameters:
+. service_name - string representing the service being published
+
+Output parameters:
+. port - string representing the port on which to contact the service
+
+Return values:
++ PMI_SUCCESS - port for service successfully obtained
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to lookup service
+
+
+@*/
+int PMI_Lookup_name( const char service_name[], char port[] );
+
+/*@
+PMI_Barrier - barrier across the process group
+
+Return values:
++ PMI_SUCCESS - barrier successfully finished
+- PMI_FAIL - barrier failed
+
+Notes:
+This function is a collective call across all processes in the process group
+the local process belongs to.  It will not return until all the processes
+have called 'PMI_Barrier()'.
+
+@*/
+int PMI_Barrier( void );
+
+/*@
+PMI_Abort - abort the process group associated with this process
+
+Input Parameters:
++ exit_code - exit code to be returned by this process
+- error_msg - error message to be printed
+
+Return values:
+. none - this function should not return
+@*/
+int PMI_Abort(int exit_code, const char error_msg[]);
+
+/* PMI Keymap functions */
+/*@
+PMI_KVS_Get_my_name - obtain the name of the keyval space the local process group has access to
+
+Input Parameters:
+. length - length of the kvsname character array
+
+Output Parameters:
+. kvsname - a string that receives the keyval space name
+
+Return values:
++ PMI_SUCCESS - kvsname successfully obtained
+. PMI_ERR_INVALID_ARG - invalid argument
+. PMI_ERR_INVALID_LENGTH - invalid length argument
+- PMI_FAIL - unable to return the kvsname
+
+Notes:
+This function returns the name of the keyval space that this process and all
+other processes in the process group have access to.  The output parameter,
+kvsname, must be at least as long as the value returned by
+'PMI_KVS_Get_name_length_max()'.
+
+@*/
+int PMI_KVS_Get_my_name( char kvsname[], int length );
+
+/*@
+PMI_KVS_Get_name_length_max - obtain the length necessary to store a kvsname
+
+Output Parameter:
+. length - maximum length required to hold a keyval space name
+
+Return values:
++ PMI_SUCCESS - length successfully set
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to set the length
+
+Notes:
+This function returns the string length required to store a keyval space name.
+
+A routine is used rather than setting a maximum value in 'pmi.h' to allow
+different implementations of PMI to be used with the same executable.  These
+different implementations may allow different maximum lengths; by using a
+routine here, we can interface with a variety of implementations of PMI.
+
+@*/
+int PMI_KVS_Get_name_length_max( int *length );
+
+/*@
+PMI_KVS_Get_key_length_max - obtain the length necessary to store a key
+
+Output Parameter:
+. length - maximum length required to hold a key string.
+
+Return values:
++ PMI_SUCCESS - length successfully set
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to set the length
+
+Notes:
+This function returns the string length required to store a key.
+
+@*/
+int PMI_KVS_Get_key_length_max( int *length );
+
+/*@
+PMI_KVS_Get_value_length_max - obtain the length necessary to store a value
+
+Output Parameter:
+. length - maximum length required to hold a keyval space value
+
+Return values:
++ PMI_SUCCESS - length successfully set
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to set the length
+
+Notes:
+This function returns the string length required to store a value from a
+keyval space.
+
+@*/
+int PMI_KVS_Get_value_length_max( int *length );
+
+/*@
+PMI_KVS_Put - put a key/value pair in a keyval space
+
+Input Parameters:
++ kvsname - keyval space name
+. key - key
+- value - value
+
+Return values:
++ PMI_SUCCESS - keyval pair successfully put in keyval space
+. PMI_ERR_INVALID_KVS - invalid kvsname argument
+. PMI_ERR_INVALID_KEY - invalid key argument
+. PMI_ERR_INVALID_VAL - invalid val argument
+- PMI_FAIL - put failed
+
+Notes:
+This function puts the key/value pair in the specified keyval space.  The
+value is not visible to other processes until 'PMI_KVS_Commit()' is called.
+The function may complete locally.  After 'PMI_KVS_Commit()' is called, the
+value may be retrieved by calling 'PMI_KVS_Get()'.  All keys put to a keyval
+space must be unique to the keyval space.  You may not put more than once
+with the same key.
+
+@*/
+int PMI_KVS_Put( const char kvsname[], const char key[], const char value[]);
+
+/*@
+PMI_KVS_Commit - commit all previous puts to the keyval space
+
+Input Parameters:
+. kvsname - keyval space name
+
+Return values:
++ PMI_SUCCESS - commit succeeded
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - commit failed
+
+Notes:
+This function commits all previous puts since the last 'PMI_KVS_Commit()' into
+the specified keyval space. It is a process local operation.
+
+@*/
+int PMI_KVS_Commit( const char kvsname[] );
+
+/*@
+PMI_KVS_Get - get a key/value pair from a keyval space
+
+Input Parameters:
++ kvsname - keyval space name
+. key - key
+- length - length of value character array
+
+Output Parameters:
+. value - value
+
+Return values:
++ PMI_SUCCESS - get succeeded
+. PMI_ERR_INVALID_KVS - invalid kvsname argument
+. PMI_ERR_INVALID_KEY - invalid key argument
+. PMI_ERR_INVALID_VAL - invalid val argument
+. PMI_ERR_INVALID_LENGTH - invalid length argument
+- PMI_FAIL - get failed
+
+Notes:
+This function gets the value of the specified key in the keyval space.
+
+@*/
+int PMI_KVS_Get( const char kvsname[], const char key[], char value[], int length);
+
+/* PMI Process Creation functions */
+
+/*S
+PMI_keyval_t - keyval structure used by PMI_Spawn_mulitiple
+
+Fields:
++ key - name of the key
+- val - value of the key
+
+S*/
+typedef struct PMI_keyval_t
+{
+    const char * key;
+    char * val;
+} PMI_keyval_t;
+
+/*@
+PMI_Spawn_multiple - spawn a new set of processes
+
+Input Parameters:
++ count - count of commands
+. cmds - array of command strings
+. argvs - array of argv arrays for each command string
+. maxprocs - array of maximum processes to spawn for each command string
+. info_keyval_sizes - array giving the number of elements in each of the
+  'info_keyval_vectors'
+. info_keyval_vectors - array of keyval vector arrays
+. preput_keyval_size - Number of elements in 'preput_keyval_vector'
+- preput_keyval_vector - array of keyvals to be pre-put in the spawned keyval space
+
+Output Parameter:
+. errors - array of errors for each command
+
+Return values:
++ PMI_SUCCESS - spawn successful
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - spawn failed
+
+Notes:
+This function spawns a set of processes into a new process group.  The 'count'
+field refers to the size of the array parameters - 'cmd', 'argvs', 'maxprocs',
+'info_keyval_sizes' and 'info_keyval_vectors'.  The 'preput_keyval_size' refers
+to the size of the 'preput_keyval_vector' array.  The 'preput_keyval_vector'
+contains keyval pairs that will be put in the keyval space of the newly
+created process group before the processes are started.  The 'maxprocs' array
+specifies the desired number of processes to create for each 'cmd' string.
+The actual number of processes may be less than the numbers specified in
+maxprocs.  The acceptable number of processes spawned may be controlled by
+``soft'' keyvals in the info arrays.  The ``soft'' option is specified by
+mpiexec in the MPI-2 standard.  Environment variables may be passed to the
+spawned processes through PMI implementation specific 'info_keyval' parameters.
+@*/
+int PMI_Spawn_multiple(int count,
+                       const char * cmds[],
+                       const char ** argvs[],
+                       const int maxprocs[],
+                       const int info_keyval_sizesp[],
+                       const PMI_keyval_t * info_keyval_vectors[],
+                       int preput_keyval_size,
+                       const PMI_keyval_t preput_keyval_vector[],
+                       int errors[]);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/shmem_pmi/simple_pmi.c
+++ b/shmem_pmi/simple_pmi.c
@@ -1,0 +1,1348 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2001 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+/*********************** PMI implementation ********************************/
+/*
+ * This file implements the client-side of the PMI interface.
+ *
+ * Note that the PMI client code must not print error messages (except
+ * when an abort is required) because MPI error handling is based on
+ * reporting error codes to which messages are attached.
+ *
+ * In v2, we should require a PMI client interface to use MPI error codes
+ * to provide better integration with MPICH.
+ */
+/***************************************************************************/
+
+#define PMI_VERSION    1
+#define PMI_SUBVERSION 1
+
+#include <stdio.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+#ifdef HAVE_STRINGS_H
+#include <strings.h>
+#endif
+#ifdef USE_PMI_PORT
+#ifndef MAXHOSTNAME
+#define MAXHOSTNAME 256
+#endif
+#endif
+/* This should be moved to pmiu for shutdown */
+#if defined(HAVE_SYS_SOCKET_H)
+#include <sys/socket.h>
+#endif
+
+/* Temporary debug definitions */
+/* #define DBG_PRINTF(args) printf args ; fflush(stdout) */
+#define DBG_PRINTF(args)
+
+#include "pmi.h"
+#include "simple_pmiutil.h"
+
+/*
+   These are global variable used *ONLY* in this file, and are hence
+   declared static.
+ */
+
+
+static int PMI_fd = -1;
+static int PMI_size = 1;
+static int PMI_rank = 0;
+
+/* Set PMI_initialized to 1 for singleton init but no process manager
+   to help.  Initialized to 2 for normal initialization.  Initialized
+   to values higher than 2 when singleton_init by a process manager.
+   All values higher than 1 invlove a PM in some way.
+*/
+typedef enum { PMI_UNINITIALIZED = 0,
+               SINGLETON_INIT_BUT_NO_PM = 1,
+	       NORMAL_INIT_WITH_PM,
+	       SINGLETON_INIT_WITH_PM } PMIState;
+static PMIState PMI_initialized = PMI_UNINITIALIZED;
+
+/* ALL GLOBAL VARIABLES MUST BE INITIALIZED TO AVOID POLLUTING THE
+   LIBRARY WITH COMMON SYMBOLS */
+static int PMI_kvsname_max = 0;
+static int PMI_keylen_max = 0;
+static int PMI_vallen_max = 0;
+
+static int PMI_debug = 0;
+static int PMI_debug_init = 0;    /* Set this to true to debug the init
+				     handshakes */
+static int PMI_spawned = 0;
+
+/* Function prototypes for internal routines */
+static int PMII_getmaxes( int *kvsname_max, int *keylen_max, int *vallen_max );
+static int PMII_Set_from_port( int, int );
+static int PMII_Connect_to_pm( char *, int );
+
+static int GetResponse( const char [], const char [], int );
+static int getPMIFD( int * );
+
+#ifdef USE_PMI_PORT
+static int PMII_singinit(void);
+static int PMI_totalview = 0;
+#endif
+static int PMIi_InitIfSingleton(void);
+static int accept_one_connection(int);
+static char cached_singinit_key[PMIU_MAXLINE];
+static char cached_singinit_val[PMIU_MAXLINE];
+static char singinit_kvsname[256];
+
+/******************************** Group functions *************************/
+
+int PMI_Init( int *spawned )
+{
+    char *p;
+    int notset = 1;
+    int rc;
+
+    PMI_initialized = PMI_UNINITIALIZED;
+
+    /* FIXME: Why is setvbuf commented out? */
+    /* FIXME: What if the output should be fully buffered (directed to file)?
+       unbuffered (user explicitly set?) */
+    /* setvbuf(stdout,0,_IONBF,0); */
+    setbuf(stdout,NULL);
+    /* PMIU_printf( 1, "PMI_INIT\n" ); */
+
+    /* Get the value of PMI_DEBUG from the environment if possible, since
+       we may have set it to help debug the setup process */
+    p = getenv( "PMI_DEBUG" );
+    if (p) PMI_debug = atoi( p );
+
+    /* Get the fd for PMI commands; if none, we're a singleton */
+    rc = getPMIFD(&notset);
+    if (rc) {
+	return rc;
+    }
+
+    if ( PMI_fd == -1 ) {
+	/* Singleton init: Process not started with mpiexec,
+	   so set size to 1, rank to 0 */
+	PMI_size = 1;
+	PMI_rank = 0;
+	*spawned = 0;
+
+	PMI_initialized = SINGLETON_INIT_BUT_NO_PM;
+	/* 256 is picked as the minimum allowed length by the PMI servers */
+	PMI_kvsname_max = 256;
+	PMI_keylen_max  = 256;
+	PMI_vallen_max  = 256;
+
+	return( 0 );
+    }
+
+    /* If size, rank, and debug are not set from a communication port,
+       use the environment */
+    if (notset) {
+	if ( ( p = getenv( "PMI_SIZE" ) ) )
+	    PMI_size = atoi( p );
+	else
+	    PMI_size = 1;
+
+	if ( ( p = getenv( "PMI_RANK" ) ) ) {
+	    PMI_rank = atoi( p );
+	    /* Let the util routine know the rank of this process for
+	       any messages (usually debugging or error) */
+	    PMIU_Set_rank( PMI_rank );
+	}
+	else
+	    PMI_rank = 0;
+
+	if ( ( p = getenv( "PMI_DEBUG" ) ) )
+	    PMI_debug = atoi( p );
+	else
+	    PMI_debug = 0;
+
+	/* Leave unchanged otherwise, which indicates that no value
+	   was set */
+    }
+
+/* FIXME: Why does this depend on their being a port??? */
+/* FIXME: What is this for? */
+#ifdef USE_PMI_PORT
+    if ( ( p = getenv( "PMI_TOTALVIEW" ) ) )
+	PMI_totalview = atoi( p );
+    if ( PMI_totalview ) {
+	char buf[PMIU_MAXLINE], cmd[PMIU_MAXLINE];
+	/* FIXME: This should use a cmd/response rather than a expecting the
+	   server to set a value in this and only this case */
+	/* FIXME: And it most ceratainly should not happen *before* the
+	   initialization handshake */
+	PMIU_readline( PMI_fd, buf, PMIU_MAXLINE );
+	PMIU_parse_keyvals( buf );
+	PMIU_getval( "cmd", cmd, PMIU_MAXLINE );
+	if ( strncmp( cmd, "tv_ready", PMIU_MAXLINE ) != 0 ) {
+	    PMIU_printf( 1, "expecting cmd=tv_ready, got %s\n", buf );
+	    return( PMI_FAIL );
+	}
+    }
+#endif
+
+    PMII_getmaxes( &PMI_kvsname_max, &PMI_keylen_max, &PMI_vallen_max );
+
+    /* FIXME: This is something that the PM should tell the process,
+       rather than deliver it through the environment */
+    if ( ( p = getenv( "PMI_SPAWNED" ) ) )
+	PMI_spawned = atoi( p );
+    else
+	PMI_spawned = 0;
+    if (PMI_spawned)
+	*spawned = 1;
+    else
+	*spawned = 0;
+
+    if ( ! PMI_initialized )
+	PMI_initialized = NORMAL_INIT_WITH_PM;
+
+    return( 0 );
+}
+
+int PMI_Initialized( int *initialized )
+{
+    /* Turn this into a logical value (1 or 0) .  This allows us
+       to use PMI_initialized to distinguish between initialized with
+       an PMI service (e.g., via mpiexec) and the singleton init,
+       which has no PMI service */
+    *initialized = (PMI_initialized != 0);
+    return PMI_SUCCESS;
+}
+
+int PMI_Get_size( int *size )
+{
+    if ( PMI_initialized )
+	*size = PMI_size;
+    else
+	*size = 1;
+    return( 0 );
+}
+
+int PMI_Get_rank( int *rank )
+{
+    if ( PMI_initialized )
+	*rank = PMI_rank;
+    else
+	*rank = 0;
+    return( 0 );
+}
+
+/*
+ * Get_universe_size is one of the routines that needs to communicate
+ * with the process manager.  If we started as a singleton init, then
+ * we first need to connect to the process manager and acquire the
+ * needed information.
+ */
+int PMI_Get_universe_size( int *size)
+{
+    int  err;
+    char size_c[PMIU_MAXLINE];
+
+    /* Connect to the PM if we haven't already */
+    if (PMIi_InitIfSingleton() != 0) return -1;
+
+    if ( PMI_initialized > SINGLETON_INIT_BUT_NO_PM)  {
+	err = GetResponse( "cmd=get_universe_size\n", "universe_size", 0 );
+	if (err == PMI_SUCCESS) {
+	    PMIU_getval( "size", size_c, PMIU_MAXLINE );
+	    *size = atoi(size_c);
+	    return( PMI_SUCCESS );
+	}
+	else return err;
+    }
+    else
+	*size = 1;
+    return( PMI_SUCCESS );
+}
+
+int PMI_Get_appnum( int *appnum )
+{
+    int  err;
+    char appnum_c[PMIU_MAXLINE];
+
+    if ( PMI_initialized > SINGLETON_INIT_BUT_NO_PM) {
+	err = GetResponse( "cmd=get_appnum\n", "appnum", 0 );
+	if (err == PMI_SUCCESS) {
+	    PMIU_getval( "appnum", appnum_c, PMIU_MAXLINE );
+	    *appnum = atoi(appnum_c);
+	    return( PMI_SUCCESS );
+	}
+	else return err;
+
+    }
+    else
+	*appnum = -1;
+
+    return( PMI_SUCCESS );
+}
+
+int PMI_Barrier( void )
+{
+    int err = PMI_SUCCESS;
+
+    if ( PMI_initialized > SINGLETON_INIT_BUT_NO_PM) {
+	err = GetResponse( "cmd=barrier_in\n", "barrier_out", 0 );
+    }
+
+    return err;
+}
+
+/* Inform the process manager that we're in finalize */
+int PMI_Finalize( void )
+{
+    int err = PMI_SUCCESS;
+
+    if ( PMI_initialized > SINGLETON_INIT_BUT_NO_PM) {
+	err = GetResponse( "cmd=finalize\n", "finalize_ack", 0 );
+	shutdown( PMI_fd, SHUT_RDWR );
+	close( PMI_fd );
+    }
+
+    return err;
+}
+
+int PMI_Abort(int exit_code, const char error_msg[])
+{
+    PMIU_printf(1, "aborting job:\n%s\n", error_msg);
+    MPIU_Exit(exit_code);
+    return -1;
+}
+
+/************************************* Keymap functions **********************/
+
+/*FIXME: need to return an error if the value of the kvs name returned is
+  truncated because it is larger than length */
+/* FIXME: My name should be cached rather than re-acquired, as it is
+   unchanging (after singleton init) */
+int PMI_KVS_Get_my_name( char kvsname[], int length )
+{
+    int err;
+
+    if (PMI_initialized == SINGLETON_INIT_BUT_NO_PM) {
+	/* Return a dummy name */
+	/* FIXME: We need to support a distinct kvsname for each
+	   process group */
+	MPIU_Snprintf( kvsname, length, "singinit_kvs_%d_0", (int)getpid() );
+	return 0;
+    }
+    err = GetResponse( "cmd=get_my_kvsname\n", "my_kvsname", 0 );
+    if (err == PMI_SUCCESS) {
+	PMIU_getval( "kvsname", kvsname, length );
+    }
+    return err;
+}
+
+int PMI_KVS_Get_name_length_max( int *maxlen )
+{
+    if (maxlen == NULL)
+	return PMI_ERR_INVALID_ARG;
+    *maxlen = PMI_kvsname_max;
+    return PMI_SUCCESS;
+}
+
+int PMI_KVS_Get_key_length_max( int *maxlen )
+{
+    if (maxlen == NULL)
+	return PMI_ERR_INVALID_ARG;
+    *maxlen = PMI_keylen_max;
+    return PMI_SUCCESS;
+}
+
+int PMI_KVS_Get_value_length_max( int *maxlen )
+{
+    if (maxlen == NULL)
+	return PMI_ERR_INVALID_ARG;
+    *maxlen = PMI_vallen_max;
+    return PMI_SUCCESS;
+}
+
+int PMI_KVS_Put( const char kvsname[], const char key[], const char value[] )
+{
+    char buf[PMIU_MAXLINE];
+    int  err = PMI_SUCCESS;
+    int  rc;
+
+    /* This is a special hack to support singleton initialization */
+    if (PMI_initialized == SINGLETON_INIT_BUT_NO_PM) {
+	rc = MPIU_Strncpy(cached_singinit_key,key,PMI_keylen_max);
+	if (rc != 0) return PMI_FAIL;
+	rc = MPIU_Strncpy(cached_singinit_val,value,PMI_vallen_max);
+	if (rc != 0) return PMI_FAIL;
+	return 0;
+    }
+
+    rc = MPIU_Snprintf( buf, PMIU_MAXLINE,
+			"cmd=put kvsname=%s key=%s value=%s\n",
+			kvsname, key, value);
+    if (rc < 0) return PMI_FAIL;
+    err = GetResponse( buf, "put_result", 1 );
+    return err;
+}
+
+int PMI_KVS_Commit( const char kvsname[] ATTRIBUTE((unused)))
+{
+    /* no-op in this implementation */
+    return( 0 );
+}
+
+/*FIXME: need to return an error if the value returned is truncated
+  because it is larger than length */
+int PMI_KVS_Get( const char kvsname[], const char key[], char value[],
+		 int length)
+{
+    char buf[PMIU_MAXLINE];
+    int err = PMI_SUCCESS;
+    int  rc;
+
+    /* Connect to the PM if we haven't already.  This is needed in case
+       we're doing an MPI_Comm_join or MPI_Comm_connect/accept from
+       the singleton init case.  This test is here because, in the way in
+       which MPICH uses PMI, this is where the test needs to be. */
+    if (PMIi_InitIfSingleton() != 0) return -1;
+
+    rc = MPIU_Snprintf( buf, PMIU_MAXLINE, "cmd=get kvsname=%s key=%s\n",
+			kvsname, key );
+    if (rc < 0) return PMI_FAIL;
+
+    err = GetResponse( buf, "get_result", 0 );
+    if (err == PMI_SUCCESS) {
+	PMIU_getval( "rc", buf, PMIU_MAXLINE );
+	rc = atoi( buf );
+	if ( rc == 0 ) {
+	    PMIU_getval( "value", value, length );
+	    return( 0 );
+	}
+	else {
+	    return( -1 );
+	}
+    }
+
+    return err;
+}
+
+/*************************** Name Publishing functions **********************/
+
+int PMI_Publish_name( const char service_name[], const char port[] )
+{
+    char buf[PMIU_MAXLINE], cmd[PMIU_MAXLINE];
+    int err;
+
+    if ( PMI_initialized > SINGLETON_INIT_BUT_NO_PM) {
+        MPIU_Snprintf( cmd, PMIU_MAXLINE,
+		       "cmd=publish_name service=%s port=%s\n",
+		       service_name, port );
+	err = GetResponse( cmd, "publish_result", 0 );
+	if (err == PMI_SUCCESS) {
+	    PMIU_getval( "rc", buf, PMIU_MAXLINE );
+	    if ( strcmp(buf,"0") != 0 ) {
+                PMIU_getval( "msg", buf, PMIU_MAXLINE );
+                PMIU_printf( PMI_debug, "publish failed; reason = %s\n", buf );
+
+	        return( PMI_FAIL );
+	    }
+	}
+    }
+    else
+    {
+	PMIU_printf( 1, "PMI_Publish_name called before init\n" );
+	return( PMI_FAIL );
+    }
+
+    return( PMI_SUCCESS );
+}
+
+int PMI_Unpublish_name( const char service_name[] )
+{
+    char buf[PMIU_MAXLINE], cmd[PMIU_MAXLINE];
+    int err = PMI_SUCCESS;
+
+    if ( PMI_initialized > SINGLETON_INIT_BUT_NO_PM) {
+        MPIU_Snprintf( cmd, PMIU_MAXLINE, "cmd=unpublish_name service=%s\n",
+		       service_name );
+	err = GetResponse( cmd, "unpublish_result", 0 );
+	if (err == PMI_SUCCESS) {
+	    PMIU_getval( "rc", buf, PMIU_MAXLINE );
+	    if ( strcmp(buf,"0") != 0 ) {
+                PMIU_getval( "msg", buf, PMIU_MAXLINE );
+                PMIU_printf( PMI_debug, "unpublish failed; reason = %s\n", buf );
+
+                return( PMI_FAIL );
+	    }
+	}
+    }
+    else
+    {
+	PMIU_printf( 1, "PMI_Unpublish_name called before init\n" );
+	return( PMI_FAIL );
+    }
+
+    return( PMI_SUCCESS );
+}
+
+int PMI_Lookup_name( const char service_name[], char port[] )
+{
+    char buf[PMIU_MAXLINE], cmd[PMIU_MAXLINE];
+    int err;
+
+    if ( PMI_initialized > SINGLETON_INIT_BUT_NO_PM) {
+        MPIU_Snprintf( cmd, PMIU_MAXLINE, "cmd=lookup_name service=%s\n",
+		       service_name );
+	err = GetResponse( cmd, "lookup_result", 0 );
+	if (err == PMI_SUCCESS) {
+	    PMIU_getval( "rc", buf, PMIU_MAXLINE );
+	    if ( strcmp(buf,"0") != 0 ) {
+                PMIU_getval( "msg", buf, PMIU_MAXLINE );
+                PMIU_printf( PMI_debug, "lookup failed; reason = %s\n", buf );
+
+	        return( PMI_FAIL );
+	    }
+	    PMIU_getval( "port", port, MPI_MAX_PORT_NAME );
+	}
+    }
+    else
+    {
+	PMIU_printf( 1, "PMI_Lookup_name called before init\n" );
+	return( PMI_FAIL );
+    }
+
+    return( PMI_SUCCESS );
+}
+
+
+/************************** Process Creation functions **********************/
+
+int PMI_Spawn_multiple(int count,
+                       const char * cmds[],
+                       const char ** argvs[],
+                       const int maxprocs[],
+                       const int info_keyval_sizes[],
+                       const PMI_keyval_t * info_keyval_vectors[],
+                       int preput_keyval_size,
+                       const PMI_keyval_t preput_keyval_vector[],
+                       int errors[])
+{
+    int  i,rc,argcnt,spawncnt,total_num_processes,num_errcodes_found;
+    char buf[PMIU_MAXLINE], tempbuf[PMIU_MAXLINE], cmd[PMIU_MAXLINE];
+    char *lead, *lag;
+
+    /* Connect to the PM if we haven't already */
+    if (PMIi_InitIfSingleton() != 0) return -1;
+
+    total_num_processes = 0;
+
+    for (spawncnt=0; spawncnt < count; spawncnt++)
+    {
+        total_num_processes += maxprocs[spawncnt];
+
+        rc = MPIU_Snprintf(buf, PMIU_MAXLINE,
+			   "mcmd=spawn\nnprocs=%d\nexecname=%s\n",
+			   maxprocs[spawncnt], cmds[spawncnt] );
+	if (rc < 0) {
+	    return PMI_FAIL;
+	}
+
+	rc = MPIU_Snprintf(tempbuf, PMIU_MAXLINE,
+			   "totspawns=%d\nspawnssofar=%d\n",
+			   count, spawncnt+1);
+
+	if (rc < 0) {
+	    return PMI_FAIL;
+	}
+	rc = MPIU_Strnapp(buf,tempbuf,PMIU_MAXLINE);
+	if (rc != 0) {
+	    return PMI_FAIL;
+	}
+
+        argcnt = 0;
+        if ((argvs != NULL) && (argvs[spawncnt] != NULL)) {
+            for (i=0; argvs[spawncnt][i] != NULL; i++)
+            {
+		/* FIXME (protocol design flaw): command line arguments
+		   may contain both = and <space> (and even tab!).
+		*/
+		/* Note that part of this fixme was really a design error -
+		   because this uses the mcmd form, the data can be
+		   sent in multiple writelines.  This code now takes
+		   advantage of that.  Note also that a correct parser
+		   of the commands will permit any character other than a
+		   new line in the argument, since the form is
+		   argn=<any nonnewline><newline> */
+                rc = MPIU_Snprintf(tempbuf,PMIU_MAXLINE,"arg%d=%s\n",
+				   i+1,argvs[spawncnt][i]);
+		if (rc < 0) {
+		    return PMI_FAIL;
+		}
+                rc = MPIU_Strnapp(buf,tempbuf,PMIU_MAXLINE);
+		if (rc != 0) {
+		    return PMI_FAIL;
+		}
+                argcnt++;
+		rc = PMIU_writeline( PMI_fd, buf );
+		buf[0] = 0;
+
+            }
+        }
+        rc = MPIU_Snprintf(tempbuf,PMIU_MAXLINE,"argcnt=%d\n",argcnt);
+	if (rc < 0) {
+	    return PMI_FAIL;
+	}
+        rc = MPIU_Strnapp(buf,tempbuf,PMIU_MAXLINE);
+	if (rc != 0) {
+	    return PMI_FAIL;
+	}
+
+        rc = MPIU_Snprintf(tempbuf,PMIU_MAXLINE,"preput_num=%d\n",
+			   preput_keyval_size);
+	if (rc < 0) {
+	    return PMI_FAIL;
+	}
+
+        rc = MPIU_Strnapp(buf,tempbuf,PMIU_MAXLINE);
+	if (rc != 0) {
+	    return PMI_FAIL;
+	}
+        for (i=0; i < preput_keyval_size; i++) {
+	    rc = MPIU_Snprintf(tempbuf,PMIU_MAXLINE,"preput_key_%d=%s\n",
+			       i,preput_keyval_vector[i].key);
+	    if (rc < 0) {
+		return PMI_FAIL;
+	    }
+	    rc = MPIU_Strnapp(buf,tempbuf,PMIU_MAXLINE);
+	    if (rc != 0) {
+		return PMI_FAIL;
+	    }
+	    rc = MPIU_Snprintf(tempbuf,PMIU_MAXLINE,"preput_val_%d=%s\n",
+			       i,preput_keyval_vector[i].val);
+	    if (rc < 0) {
+		return PMI_FAIL;
+	    }
+	    rc = MPIU_Strnapp(buf,tempbuf,PMIU_MAXLINE);
+	    if (rc != 0) {
+		return PMI_FAIL;
+	    }
+        }
+        rc = MPIU_Snprintf(tempbuf,PMIU_MAXLINE,"info_num=%d\n",
+			   info_keyval_sizes[spawncnt]);
+	if (rc < 0) {
+	    return PMI_FAIL;
+	}
+        rc = MPIU_Strnapp(buf,tempbuf,PMIU_MAXLINE);
+	if (rc != 0) {
+	    return PMI_FAIL;
+	}
+	for (i=0; i < info_keyval_sizes[spawncnt]; i++)
+	{
+	    rc = MPIU_Snprintf(tempbuf,PMIU_MAXLINE,"info_key_%d=%s\n",
+			       i,info_keyval_vectors[spawncnt][i].key);
+	    if (rc < 0) {
+		return PMI_FAIL;
+	    }
+	    rc = MPIU_Strnapp(buf,tempbuf,PMIU_MAXLINE);
+	    if (rc != 0) {
+		return PMI_FAIL;
+	    }
+	    rc = MPIU_Snprintf(tempbuf,PMIU_MAXLINE,"info_val_%d=%s\n",
+			       i,info_keyval_vectors[spawncnt][i].val);
+	    if (rc < 0) {
+		return PMI_FAIL;
+	    }
+	    rc = MPIU_Strnapp(buf,tempbuf,PMIU_MAXLINE);
+	    if (rc != 0) {
+		return PMI_FAIL;
+	    }
+	}
+
+        rc = MPIU_Strnapp(buf, "endcmd\n", PMIU_MAXLINE);
+	if (rc != 0) {
+	    return PMI_FAIL;
+	}
+        PMIU_writeline( PMI_fd, buf );
+    }
+
+    PMIU_readline( PMI_fd, buf, PMIU_MAXLINE );
+    PMIU_parse_keyvals( buf );
+    PMIU_getval( "cmd", cmd, PMIU_MAXLINE );
+    if ( strncmp( cmd, "spawn_result", PMIU_MAXLINE ) != 0 ) {
+	PMIU_printf( 1, "got unexpected response to spawn :%s:\n", buf );
+	return( -1 );
+    }
+    else {
+	PMIU_getval( "rc", buf, PMIU_MAXLINE );
+	rc = atoi( buf );
+	if ( rc != 0 ) {
+	    /****
+	    PMIU_getval( "status", tempbuf, PMIU_MAXLINE );
+	    PMIU_printf( 1, "pmi_spawn_mult failed; status: %s\n",tempbuf);
+	    ****/
+	    return( -1 );
+	}
+    }
+
+    PMIU_Assert(errors != NULL);
+    if (PMIU_getval( "errcodes", tempbuf, PMIU_MAXLINE )) {
+        num_errcodes_found = 0;
+        lag = &tempbuf[0];
+        do {
+            lead = strchr(lag, ',');
+            if (lead) *lead = '\0';
+            errors[num_errcodes_found++] = atoi(lag);
+            lag = lead + 1; /* move past the null char */
+            PMIU_Assert(num_errcodes_found <= total_num_processes);
+        } while (lead != NULL);
+        PMIU_Assert(num_errcodes_found == total_num_processes);
+    }
+    else {
+        /* gforker doesn't return errcodes, so we'll just pretend that means
+           that it was going to send all `0's. */
+        for (i = 0; i < total_num_processes; ++i) {
+            errors[i] = 0;
+        }
+    }
+
+    return( 0 );
+}
+
+/***************** Internal routines not part of PMI interface ***************/
+
+/* to get all maxes in one message */
+/* FIXME: This mixes init with get maxes */
+static int PMII_getmaxes( int *kvsname_max, int *keylen_max, int *vallen_max )
+{
+    char buf[PMIU_MAXLINE], cmd[PMIU_MAXLINE], errmsg[PMIU_MAXLINE];
+    int err, rc;
+
+    rc = MPIU_Snprintf( buf, PMIU_MAXLINE,
+			"cmd=init pmi_version=%d pmi_subversion=%d\n",
+			PMI_VERSION, PMI_SUBVERSION );
+    if (rc < 0) {
+	return PMI_FAIL;
+    }
+
+    rc = PMIU_writeline( PMI_fd, buf );
+    if (rc != 0) {
+	PMIU_printf( 1, "Unable to write to PMI_fd\n" );
+	return PMI_FAIL;
+    }
+    buf[0] = 0;   /* Ensure buffer is empty if read fails */
+    err = PMIU_readline( PMI_fd, buf, PMIU_MAXLINE );
+    if (err < 0) {
+	PMIU_printf( 1, "Error reading initack on %d\n", PMI_fd );
+	perror( "Error on readline:" );
+	PMI_Abort(-1, "Above error when reading after init" );
+    }
+    PMIU_parse_keyvals( buf );
+    cmd[0] = 0;
+    PMIU_getval( "cmd", cmd, PMIU_MAXLINE );
+    if ( strncmp( cmd, "response_to_init", PMIU_MAXLINE ) != 0 ) {
+	MPIU_Snprintf(errmsg, PMIU_MAXLINE,
+		      "got unexpected response to init :%s: (full line = %s)",
+		      cmd, buf  );
+	PMI_Abort( -1, errmsg );
+    }
+    else {
+	char buf1[PMIU_MAXLINE];
+        PMIU_getval( "rc", buf, PMIU_MAXLINE );
+        if ( strncmp( buf, "0", PMIU_MAXLINE ) != 0 ) {
+            PMIU_getval( "pmi_version", buf, PMIU_MAXLINE );
+            PMIU_getval( "pmi_subversion", buf1, PMIU_MAXLINE );
+	    MPIU_Snprintf(errmsg, PMIU_MAXLINE,
+			  "pmi_version mismatch; client=%d.%d mgr=%s.%s",
+			  PMI_VERSION, PMI_SUBVERSION, buf, buf1 );
+	    PMI_Abort( -1, errmsg );
+        }
+    }
+    err = GetResponse( "cmd=get_maxes\n", "maxes", 0 );
+    if (err == PMI_SUCCESS) {
+	PMIU_getval( "kvsname_max", buf, PMIU_MAXLINE );
+	*kvsname_max = atoi( buf );
+	PMIU_getval( "keylen_max", buf, PMIU_MAXLINE );
+	*keylen_max = atoi( buf );
+	PMIU_getval( "vallen_max", buf, PMIU_MAXLINE );
+	*vallen_max = atoi( buf );
+    }
+    return err;
+}
+
+/* ----------------------------------------------------------------------- */
+/*
+ * This function is used to request information from the server and check
+ * that the response uses the expected command name.  On a successful
+ * return from this routine, additional PMIU_getval calls may be used
+ * to access information about the returned value.
+ *
+ * If checkRc is true, this routine also checks that the rc value returned
+ * was 0.  If not, it uses the "msg" value to report on the reason for
+ * the failure.
+ */
+static int GetResponse( const char request[], const char expectedCmd[],
+			int checkRc )
+{
+    int err, n;
+    char *p;
+    char recvbuf[PMIU_MAXLINE];
+    char cmdName[PMIU_MAXLINE];
+
+    /* FIXME: This is an example of an incorrect fix - writeline can change
+       the second argument in some cases, and that will break the const'ness
+       of request.  Instead, writeline should take a const item and return
+       an error in the case in which it currently truncates the data. */
+    err = PMIU_writeline( PMI_fd, (char *)request );
+    if (err) {
+	return err;
+    }
+    n = PMIU_readline( PMI_fd, recvbuf, sizeof(recvbuf) );
+    if (n <= 0) {
+	PMIU_printf( 1, "readline failed\n" );
+	return PMI_FAIL;
+    }
+    err = PMIU_parse_keyvals( recvbuf );
+    if (err) {
+	PMIU_printf( 1, "parse_kevals failed %d\n", err );
+	return err;
+    }
+    p = PMIU_getval( "cmd", cmdName, sizeof(cmdName) );
+    if (!p) {
+	PMIU_printf( 1, "getval cmd failed\n" );
+	return PMI_FAIL;
+    }
+    if (strcmp( expectedCmd, cmdName ) != 0) {
+	PMIU_printf( 1, "expecting cmd=%s, got %s\n", expectedCmd, cmdName );
+	return PMI_FAIL;
+    }
+    if (checkRc) {
+	p = PMIU_getval( "rc", cmdName, PMIU_MAXLINE );
+	if ( p && strcmp(cmdName,"0") != 0 ) {
+	    PMIU_getval( "msg", cmdName, PMIU_MAXLINE );
+	    PMIU_printf( 1, "Command %s failed, reason='%s'\n",
+			 request, cmdName );
+	    return PMI_FAIL;
+	}
+    }
+
+    return err;
+}
+/* ----------------------------------------------------------------------- */
+
+
+#ifdef USE_PMI_PORT
+/*
+ * This code allows a program to contact a host/port for the PMI socket.
+ */
+#include <errno.h>
+#if defined(HAVE_SYS_TYPES_H)
+#include <sys/types.h>
+#endif
+#include <sys/param.h>
+#include <sys/socket.h>
+
+/* sockaddr_in (Internet) */
+#include <netinet/in.h>
+/* TCP_NODELAY */
+#include <netinet/tcp.h>
+
+/* sockaddr_un (Unix) */
+#include <sys/un.h>
+
+/* defs of gethostbyname */
+#include <netdb.h>
+
+/* fcntl, F_GET/SETFL */
+#include <fcntl.h>
+
+/* This is really IP!? */
+#ifndef TCP
+#define TCP 0
+#endif
+
+/* stub for connecting to a specified host/port instead of using a
+   specified fd inherited from a parent process */
+static int PMII_Connect_to_pm( char *hostname, int portnum )
+{
+    struct hostent     *hp;
+    struct sockaddr_in sa;
+    int                fd;
+    int                optval = 1;
+    int                q_wait = 1;
+
+    hp = gethostbyname( hostname );
+    if (!hp) {
+	PMIU_printf( 1, "Unable to get host entry for %s\n", hostname );
+	return -1;
+    }
+
+    memset( (void *)&sa, 0, sizeof(sa) );
+    /* POSIX might define h_addr_list only and node define h_addr */
+#ifdef HAVE_H_ADDR_LIST
+    memcpy( (void *)&sa.sin_addr, (void *)hp->h_addr_list[0], hp->h_length);
+#else
+    memcpy( (void *)&sa.sin_addr, (void *)hp->h_addr, hp->h_length);
+#endif
+    sa.sin_family = hp->h_addrtype;
+    sa.sin_port   = htons( (unsigned short) portnum );
+
+    fd = socket( AF_INET, SOCK_STREAM, TCP );
+    if (fd < 0) {
+	PMIU_printf( 1, "Unable to get AF_INET socket\n" );
+	return -1;
+    }
+
+    if (setsockopt( fd, IPPROTO_TCP, TCP_NODELAY,
+		    (char *)&optval, sizeof(optval) )) {
+	perror( "Error calling setsockopt:" );
+    }
+
+    /* We wait here for the connection to succeed */
+    if (connect( fd, (struct sockaddr *)&sa, sizeof(sa) ) < 0) {
+	switch (errno) {
+	case ECONNREFUSED:
+	    PMIU_printf( 1, "connect failed with connection refused\n" );
+	    /* (close socket, get new socket, try again) */
+	    if (q_wait)
+		close(fd);
+	    return -1;
+
+	case EINPROGRESS: /*  (nonblocking) - select for writing. */
+	    break;
+
+	case EISCONN: /*  (already connected) */
+	    break;
+
+	case ETIMEDOUT: /* timed out */
+	    PMIU_printf( 1, "connect failed with timeout\n" );
+	    return -1;
+
+	default:
+	    PMIU_printf( 1, "connect failed with errno %d\n", errno );
+	    return -1;
+	}
+    }
+
+    return fd;
+}
+
+static int PMII_Set_from_port( int fd, int id )
+{
+    char buf[PMIU_MAXLINE], cmd[PMIU_MAXLINE];
+    int err, rc;
+
+    /* We start by sending a startup message to the server */
+
+    if (PMI_debug) {
+	PMIU_printf( 1, "Writing initack to destination fd %d\n", fd );
+    }
+    /* Handshake and initialize from a port */
+
+    rc = MPIU_Snprintf( buf, PMIU_MAXLINE, "cmd=initack pmiid=%d\n", id );
+    if (rc < 0) {
+	return PMI_FAIL;
+    }
+    PMIU_printf( PMI_debug, "writing on fd %d line :%s:\n", fd, buf );
+    err = PMIU_writeline( fd, buf );
+    if (err) {
+	PMIU_printf( 1, "Error in writeline initack\n" );
+	return -1;
+    }
+
+    /* cmd=initack */
+    buf[0] = 0;
+    PMIU_printf( PMI_debug, "reading initack\n" );
+    err = PMIU_readline( fd, buf, PMIU_MAXLINE );
+    if (err < 0) {
+	PMIU_printf( 1, "Error reading initack on %d\n", fd );
+	perror( "Error on readline:" );
+	return -1;
+    }
+    PMIU_parse_keyvals( buf );
+    PMIU_getval( "cmd", cmd, PMIU_MAXLINE );
+    if ( strcmp( cmd, "initack" ) ) {
+	PMIU_printf( 1, "got unexpected input %s\n", buf );
+	return -1;
+    }
+
+    /* Read, in order, size, rank, and debug.  Eventually, we'll want
+       the handshake to include a version number */
+
+    /* size */
+    PMIU_printf( PMI_debug, "reading size\n" );
+    err = PMIU_readline( fd, buf, PMIU_MAXLINE );
+    if (err < 0) {
+	PMIU_printf( 1, "Error reading size on %d\n", fd );
+	perror( "Error on readline:" );
+	return -1;
+    }
+    PMIU_parse_keyvals( buf );
+    PMIU_getval( "cmd", cmd, PMIU_MAXLINE );
+    if ( strcmp(cmd,"set")) {
+	PMIU_printf( 1, "got unexpected command %s in %s\n", cmd, buf );
+	return -1;
+    }
+    /* cmd=set size=n */
+    PMIU_getval( "size", cmd, PMIU_MAXLINE );
+    PMI_size = atoi(cmd);
+
+    /* rank */
+    PMIU_printf( PMI_debug, "reading rank\n" );
+    err = PMIU_readline( fd, buf, PMIU_MAXLINE );
+    if (err < 0) {
+	PMIU_printf( 1, "Error reading rank on %d\n", fd );
+	perror( "Error on readline:" );
+	return -1;
+    }
+    PMIU_parse_keyvals( buf );
+    PMIU_getval( "cmd", cmd, PMIU_MAXLINE );
+    if ( strcmp(cmd,"set")) {
+	PMIU_printf( 1, "got unexpected command %s in %s\n", cmd, buf );
+	return -1;
+    }
+    /* cmd=set rank=n */
+    PMIU_getval( "rank", cmd, PMIU_MAXLINE );
+    PMI_rank = atoi(cmd);
+    PMIU_Set_rank( PMI_rank );
+
+    /* debug flag */
+    err = PMIU_readline( fd, buf, PMIU_MAXLINE );
+    if (err < 0) {
+	PMIU_printf( 1, "Error reading debug on %d\n", fd );
+	return -1;
+    }
+    PMIU_parse_keyvals( buf );
+    PMIU_getval( "cmd", cmd, PMIU_MAXLINE );
+    if ( strcmp(cmd,"set")) {
+	PMIU_printf( 1, "got unexpected command %s in %s\n", cmd, buf );
+	return -1;
+    }
+    /* cmd=set debug=n */
+    PMIU_getval( "debug", cmd, PMIU_MAXLINE );
+    PMI_debug = atoi(cmd);
+
+    if (PMI_debug) {
+	DBG_PRINTF( ("end of handshake, rank = %d, size = %d\n",
+		    PMI_rank, PMI_size ));
+	DBG_PRINTF( ("Completed init\n" ) );
+    }
+
+    return 0;
+}
+
+/* ------------------------------------------------------------------------- */
+/*
+ * Singleton Init.
+ *
+ * MPI-2 allows processes to become MPI processes and then make MPI calls,
+ * such as MPI_Comm_spawn, that require a process manager (this is different
+ * than the much simpler case of allowing MPI programs to run with an
+ * MPI_COMM_WORLD of size 1 without an mpiexec or process manager).
+ *
+ * The process starts when either the client or the process manager contacts
+ * the other.  If the client starts, it sends a singinit command and
+ * waits for the server to respond with its own singinit command.
+ * If the server start, it send a singinit command and waits for the
+ * client to respond with its own singinit command
+ *
+ * client sends singinit with these required values
+ *   pmi_version=<value of PMI_VERSION>
+ *   pmi_subversion=<value of PMI_SUBVERSION>
+ *
+ * and these optional values
+ *   stdio=[yes|no]
+ *   authtype=[none|shared|<other-to-be-defined>]
+ *   authstring=<string>
+ *
+ * server sends singinit with the same required and optional values as
+ * above.
+ *
+ * At this point, the protocol is now the same in both cases, and has the
+ * following components:
+ *
+ * server sends singinit_info with these required fields
+ *   versionok=[yes|no]
+ *   stdio=[yes|no]
+ *   kvsname=<string>
+ *
+ * The client then issues the init command (see PMII_getmaxes)
+ *
+ * cmd=init pmi_version=<val> pmi_subversion=<val>
+ *
+ * and expects to receive a
+ *
+ * cmd=response_to_init rc=0 pmi_version=<val> pmi_subversion=<val>
+ *
+ * (This is the usual init sequence).
+ *
+ */
+/* ------------------------------------------------------------------------- */
+/* This is a special routine used to re-initialize PMI when it is in
+   the singleton init case.  That is, the executable was started without
+   mpiexec, and PMI_Init returned as if there was only one process.
+
+   Note that PMI routines should not call PMII_singinit; they should
+   call PMIi_InitIfSingleton(), which both connects to the process mangager
+   and sets up the initial KVS connection entry.
+*/
+
+static int PMII_singinit(void)
+{
+    int pid, rc;
+    int singinit_listen_sock, stdin_sock, stdout_sock, stderr_sock;
+    const char *newargv[8];
+    char charpid[8], port_c[8];
+    struct sockaddr_in sin;
+    socklen_t len;
+
+    /* Create a socket on which to allow an mpiexec to connect back to
+       us */
+    sin.sin_family	= AF_INET;
+    sin.sin_addr.s_addr	= INADDR_ANY;
+    sin.sin_port	= htons(0);    /* anonymous port */
+    singinit_listen_sock = socket(AF_INET, SOCK_STREAM, 0);
+    rc = bind(singinit_listen_sock, (struct sockaddr *)&sin ,sizeof(sin));
+    len = sizeof(struct sockaddr_in);
+    rc = getsockname( singinit_listen_sock, (struct sockaddr *) &sin, &len );
+    MPIU_Snprintf(port_c, sizeof(port_c), "%d",ntohs(sin.sin_port));
+    rc = listen(singinit_listen_sock, 5);
+
+    PMIU_printf( PMI_debug_init, "Starting mpiexec with %s\n", port_c );
+
+    /* Launch the mpiexec process with the name of this port */
+    pid = fork();
+    if (pid < 0) {
+	perror("PMII_singinit: fork failed");
+	exit(-1);
+    }
+    else if (pid == 0) {
+	newargv[0] = "mpiexec";
+	newargv[1] = "-pmi_args";
+	newargv[2] = port_c;
+	/* FIXME: Use a valid hostname */
+	newargv[3] = "default_interface";  /* default interface name, for now */
+	newargv[4] = "default_key";   /* default authentication key, for now */
+	MPIU_Snprintf(charpid, sizeof(charpid), "%d",getpid());
+	newargv[5] = charpid;
+	newargv[6] = NULL;
+	rc = execvp(newargv[0], (char **)newargv);
+	perror("PMII_singinit: execv failed");
+	PMIU_printf(1, "  This singleton init program attempted to access some feature\n");
+	PMIU_printf(1, "  for which process manager support was required, e.g. spawn or universe_size.\n");
+	PMIU_printf(1, "  But the necessary mpiexec is not in your path.\n");
+	return(-1);
+    }
+    else
+    {
+	char buf[PMIU_MAXLINE], cmd[PMIU_MAXLINE];
+	char *p;
+	int connectStdio = 0;
+
+	/* Allow one connection back from the created mpiexec program */
+	PMI_fd =  accept_one_connection(singinit_listen_sock);
+	if (PMI_fd < 0) {
+	    PMIU_printf( 1, "Failed to establish singleton init connection\n" );
+	    return PMI_FAIL;
+	}
+	/* Execute the singleton init protocol */
+	rc = PMIU_readline( PMI_fd, buf, PMIU_MAXLINE );
+	PMIU_printf( PMI_debug_init, "Singinit: read %s\n", buf );
+
+	PMIU_parse_keyvals( buf );
+	PMIU_getval( "cmd", cmd, PMIU_MAXLINE );
+	if (strcmp( cmd, "singinit" ) != 0) {
+	    PMIU_printf( 1, "unexpected command from PM: %s\n", cmd );
+	    return PMI_FAIL;
+	}
+	p = PMIU_getval( "authtype", cmd, PMIU_MAXLINE );
+	if (p && strcmp( cmd, "none" ) != 0) {
+	    PMIU_printf( 1, "unsupported authentication method %s\n", cmd );
+	    return PMI_FAIL;
+	}
+	/* p = PMIU_getval( "authstring", cmd, PMIU_MAXLINE ); */
+
+	/* If we're successful, send back our own singinit */
+	rc = MPIU_Snprintf( buf, PMIU_MAXLINE,
+     "cmd=singinit pmi_version=%d pmi_subversion=%d stdio=yes authtype=none\n",
+			PMI_VERSION, PMI_SUBVERSION );
+	if (rc < 0) {
+	    return PMI_FAIL;
+	}
+	PMIU_printf( PMI_debug_init, "GetResponse with %s\n", buf );
+
+	rc = GetResponse( buf, "singinit_info", 0 );
+	if (rc != 0) {
+	    PMIU_printf( 1, "GetResponse failed\n" );
+	    return PMI_FAIL;
+	}
+	p = PMIU_getval( "versionok", cmd, PMIU_MAXLINE );
+	if (p && strcmp( cmd, "yes" ) != 0) {
+	    PMIU_printf( 1, "Process manager needs a different PMI version\n" );
+	    return PMI_FAIL;
+	}
+	p = PMIU_getval( "stdio", cmd, PMIU_MAXLINE );
+	if (p && strcmp( cmd, "yes" ) == 0) {
+	    PMIU_printf( PMI_debug_init, "PM agreed to connect stdio\n" );
+	    connectStdio = 1;
+	}
+	p = PMIU_getval( "kvsname", singinit_kvsname, sizeof(singinit_kvsname) );
+	PMIU_printf( PMI_debug_init, "kvsname to use is %s\n",
+		     singinit_kvsname );
+
+	if (connectStdio) {
+	    PMIU_printf( PMI_debug_init,
+			 "Accepting three connections for stdin, out, err\n" );
+	    stdin_sock  = accept_one_connection(singinit_listen_sock);
+	    dup2(stdin_sock, 0);
+	    stdout_sock = accept_one_connection(singinit_listen_sock);
+	    dup2(stdout_sock,1);
+	    stderr_sock = accept_one_connection(singinit_listen_sock);
+	    dup2(stderr_sock,2);
+	}
+	PMIU_printf( PMI_debug_init, "Done with singinit handshake\n" );
+    }
+    return 0;
+}
+
+/* Promote PMI to a fully initialized version if it was started as
+   a singleton init */
+static int PMIi_InitIfSingleton(void)
+{
+    int rc;
+    static int firstcall = 1;
+
+    if (PMI_initialized != SINGLETON_INIT_BUT_NO_PM || !firstcall) return 0;
+
+    /* We only try to init as a singleton the first time */
+    firstcall = 0;
+
+    /* First, start (if necessary) an mpiexec, connect to it,
+       and start the singleton init handshake */
+    rc = PMII_singinit();
+
+    if (rc < 0)
+	return(-1);
+    PMI_initialized = SINGLETON_INIT_WITH_PM;    /* do this right away */
+    PMI_size	    = 1;
+    PMI_rank	    = 0;
+    PMI_debug	    = 0;
+    PMI_spawned	    = 0;
+
+    PMII_getmaxes( &PMI_kvsname_max, &PMI_keylen_max, &PMI_vallen_max );
+
+    /* FIXME: We need to support a distinct kvsname for each
+       process group */
+    PMI_KVS_Put( singinit_kvsname, cached_singinit_key, cached_singinit_val );
+
+    return 0;
+}
+
+static int accept_one_connection(int list_sock)
+{
+    int gotit, new_sock;
+    struct sockaddr_in from;
+    socklen_t len;
+
+    len = sizeof(from);
+    gotit = 0;
+    while ( ! gotit )
+    {
+	new_sock = accept(list_sock, (struct sockaddr *)&from, &len);
+	if (new_sock == -1)
+	{
+	    if (errno == EINTR)    /* interrupted? If so, try again */
+		continue;
+	    else
+	    {
+		PMIU_printf(1, "accept failed in accept_one_connection\n");
+		exit(-1);
+	    }
+	}
+	else
+	    gotit = 1;
+    }
+    return(new_sock);
+}
+
+#endif
+/* end USE_PMI_PORT */
+
+/* Get the FD to use for PMI operations.  If a port is used, rather than
+   a pre-established FD (i.e., via pipe), this routine will handle the
+   initial handshake.
+*/
+static int getPMIFD( int *notset )
+{
+    char *p;
+
+    /* Set the default */
+    PMI_fd = -1;
+
+    p = getenv( "PMI_FD" );
+
+    if (p) {
+	PMI_fd = atoi( p );
+	return 0;
+    }
+
+#ifdef USE_PMI_PORT
+    p = getenv( "PMI_PORT" );
+    if (p) {
+	int portnum;
+	char hostname[MAXHOSTNAME+1];
+	char *pn, *ph;
+	int id = 0;
+
+	/* Connect to the indicated port (in format hostname:portnumber)
+	   and get the fd for the socket */
+
+	/* Split p into host and port */
+	pn = p;
+	ph = hostname;
+	while (*pn && *pn != ':' && (ph - hostname) < MAXHOSTNAME) {
+	    *ph++ = *pn++;
+	}
+	*ph = 0;
+
+	if (PMI_debug) {
+	    DBG_PRINTF( ("Connecting to %s\n", p) );
+	}
+	if (*pn == ':') {
+	    portnum = atoi( pn+1 );
+	    /* FIXME: Check for valid integer after : */
+	    /* This routine only gets the fd to use to talk to
+	       the process manager. The handshake below is used
+	       to setup the initial values */
+	    PMI_fd = PMII_Connect_to_pm( hostname, portnum );
+	    if (PMI_fd < 0) {
+		PMIU_printf( 1, "Unable to connect to %s on %d\n",
+			     hostname, portnum );
+		return -1;
+	    }
+	}
+	else {
+	    PMIU_printf( 1, "unable to decode hostport from %s\n", p );
+	    return PMI_FAIL;
+	}
+
+	/* We should first handshake to get size, rank, debug. */
+	p = getenv( "PMI_ID" );
+	if (p) {
+	    id = atoi( p );
+	    /* PMII_Set_from_port sets up the values that are delivered
+	       by enviroment variables when a separate port is not used */
+	    PMII_Set_from_port( PMI_fd, id );
+	    *notset = 0;
+	}
+	return 0;
+    }
+#endif
+
+    /* Singleton init case - its ok to return success with no fd set */
+    return 0;
+}

--- a/shmem_pmi/simple_pmiutil.c
+++ b/shmem_pmi/simple_pmiutil.c
@@ -1,0 +1,291 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2001 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+/* Allow fprintf to logfile */
+/* style: allow:fprintf:1 sig:0 */
+
+/* Utility functions associated with PMI implementation, but not part of
+   the PMI interface itself.  Reading and writing on pipes, signals, and parsing
+   key=value messages
+*/
+
+#include <stdio.h>
+#ifdef HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
+#include <stdarg.h>
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include <errno.h>
+#include "simple_pmiutil.h"
+
+
+#define MAXVALLEN 1024
+#define MAXKEYLEN   32
+
+/* These are not the keyvals in the keyval space that is part of the
+   PMI specification.
+   They are just part of this implementation's internal utilities.
+*/
+struct PMIU_keyval_pairs {
+    char key[MAXKEYLEN];
+    char value[MAXVALLEN];
+};
+static struct PMIU_keyval_pairs PMIU_keyval_tab[64] = { { {0}, {0} } };
+static int  PMIU_keyval_tab_idx = 0;
+
+/* This is used to prepend printed output.  Set the initial value to
+   "unset" */
+static char PMIU_print_id[PMIU_IDSIZE] = "unset";
+
+void PMIU_Set_rank( int PMI_rank )
+{
+    MPIU_Snprintf( PMIU_print_id, PMIU_IDSIZE, "cli_%d", PMI_rank );
+}
+void PMIU_SetServer( void )
+{
+    MPIU_Strncpy( PMIU_print_id, "server", PMIU_IDSIZE );
+}
+
+/* Note that vfprintf is part of C89 */
+
+/* style: allow:fprintf:1 sig:0 */
+/* style: allow:vfprintf:1 sig:0 */
+/* This should be combined with the message routines */
+void PMIU_printf( int print_flag, const char *fmt, ... )
+{
+    va_list ap;
+    static FILE *logfile= 0;
+
+    /* In some cases when we are debugging, the handling of stdout or
+       stderr may be unreliable.  In that case, we make it possible to
+       select an output file. */
+    if (!logfile) {
+	char *p;
+	p = getenv("PMI_USE_LOGFILE");
+	if (p) {
+	    char filename[1024];
+	    p = getenv("PMI_ID");
+	    if (p) {
+		MPIU_Snprintf( filename, sizeof(filename),
+			       "testclient-%s.out", p );
+		logfile = fopen( filename, "w" );
+	    }
+	    else {
+		logfile = fopen( "testserver.out", "w" );
+	    }
+	}
+	else
+	    logfile = stderr;
+    }
+
+    if ( print_flag ) {
+	/* MPIU_Error_printf( "[%s]: ", PMIU_print_id ); */
+	/* FIXME: Decide what role PMIU_printf should have (if any) and
+	   select the appropriate MPIU routine */
+	fprintf( logfile, "[%s]: ", PMIU_print_id );
+	va_start( ap, fmt );
+	vfprintf( logfile, fmt, ap );
+	va_end( ap );
+	fflush( logfile );
+    }
+}
+
+#define MAX_READLINE 1024
+/*
+ * Return the next newline-terminated string of maximum length maxlen.
+ * This is a buffered version, and reads from fd as necessary.  A
+ */
+int PMIU_readline( int fd, char *buf, int maxlen )
+{
+    static char readbuf[MAX_READLINE];
+    static char *nextChar = 0, *lastChar = 0;  /* lastChar is really one past
+						  last char */
+    static int lastfd = -1;
+    ssize_t n;
+    int     curlen;
+    char    *p, ch;
+
+    /* Note: On the client side, only one thread at a time should
+       be calling this, and there should only be a single fd.
+       Server side code should not use this routine (see the
+       replacement version in src/pm/util/pmiserv.c) */
+    if (nextChar != lastChar && fd != lastfd) {
+	fprintf(stderr,  "Panic - buffer inconsistent\n" );
+	return -1;
+    }
+
+    p      = buf;
+    curlen = 1;    /* Make room for the null */
+    while (curlen < maxlen) {
+	if (nextChar == lastChar) {
+	    lastfd = fd;
+	    do {
+		n = read( fd, readbuf, sizeof(readbuf)-1 );
+	    } while (n == -1 && errno == EINTR);
+	    if (n == 0) {
+		/* EOF */
+		break;
+	    }
+	    else if (n < 0) {
+		/* Error.  Return a negative value if there is no
+		   data.  Save the errno in case we need to return it
+		   later. */
+		if (curlen == 1) {
+		    curlen = 0;
+		}
+		break;
+	    }
+	    nextChar = readbuf;
+	    lastChar = readbuf + n;
+	    /* Add a null at the end just to make it easier to print
+	       the read buffer */
+	    readbuf[n] = 0;
+	    /* FIXME: Make this an optional output */
+	    /* printf( "Readline %s\n", readbuf ); */
+	}
+
+	ch   = *nextChar++;
+	*p++ = ch;
+	curlen++;
+	if (ch == '\n') break;
+    }
+
+    /* We null terminate the string for convenience in printing */
+    *p = 0;
+
+    /* Return the number of characters, not counting the null */
+    return curlen-1;
+}
+
+int PMIU_writeline( int fd, char *buf )
+{
+    ssize_t size, n;
+
+    size = strlen( buf );
+    if ( size > PMIU_MAXLINE ) {
+	buf[PMIU_MAXLINE-1] = '\0';
+	PMIU_printf( 1, "write_line: message string too big: :%s:\n", buf );
+    }
+    else if ( buf[strlen( buf ) - 1] != '\n' )  /* error:  no newline at end */
+	    PMIU_printf( 1, "write_line: message string doesn't end in newline: :%s:\n",
+		       buf );
+    else {
+	do {
+	    n = write( fd, buf, size );
+	} while (n == -1 && errno == EINTR);
+
+	if ( n < 0 ) {
+	    PMIU_printf( 1, "write_line error; fd=%d buf=:%s:\n", fd, buf );
+	    perror("system msg for write_line failure ");
+	    return(-1);
+	}
+	if ( n < size)
+	    PMIU_printf( 1, "write_line failed to write entire message\n" );
+    }
+    return 0;
+}
+
+/*
+ * Given an input string st, parse it into internal storage that can be
+ * queried by routines such as PMIU_getval.
+ */
+int PMIU_parse_keyvals( char *st )
+{
+    char *p, *keystart, *valstart;
+    int  offset;
+
+    if ( !st )
+	return( -1 );
+
+    PMIU_keyval_tab_idx = 0;
+    p = st;
+    while ( 1 ) {
+	while ( *p == ' ' )
+	    p++;
+	/* got non-blank */
+	if ( *p == '=' ) {
+	    PMIU_printf( 1, "PMIU_parse_keyvals:  unexpected = at character %d in %s\n",
+		       p - st, st );
+	    return( -1 );
+	}
+	if ( *p == '\n' || *p == '\0' )
+	    return( 0 );	/* normal exit */
+	/* got normal character */
+	keystart = p;		/* remember where key started */
+	while ( *p != ' ' && *p != '=' && *p != '\n' && *p != '\0' )
+	    p++;
+	if ( *p == ' ' || *p == '\n' || *p == '\0' ) {
+	    PMIU_printf( 1,
+       "PMIU_parse_keyvals: unexpected key delimiter at character %d in %s\n",
+		       p - st, st );
+	    return( -1 );
+	}
+	/* Null terminate the key */
+	*p = 0;
+	/* store key */
+        MPIU_Strncpy( PMIU_keyval_tab[PMIU_keyval_tab_idx].key, keystart,
+		      MAXKEYLEN );
+
+	valstart = ++p;			/* start of value */
+	while ( *p != ' ' && *p != '\n' && *p != '\0' )
+	    p++;
+	/* store value */
+        MPIU_Strncpy( PMIU_keyval_tab[PMIU_keyval_tab_idx].value, valstart,
+		      MAXVALLEN );
+	offset = (int)(p - valstart);
+	/* When compiled with -fPIC, the pgcc compiler generates incorrect
+	   code if "p - valstart" is used instead of using the
+	   intermediate offset */
+	PMIU_keyval_tab[PMIU_keyval_tab_idx].value[offset] = '\0';
+	PMIU_keyval_tab_idx++;
+	if ( *p == ' ' )
+	    continue;
+	if ( *p == '\n' || *p == '\0' )
+	    return( 0 );	/* value has been set to empty */
+    }
+}
+
+void PMIU_dump_keyvals( void )
+{
+    int i;
+    for (i=0; i < PMIU_keyval_tab_idx; i++)
+	PMIU_printf(1, "  %s=%s\n",PMIU_keyval_tab[i].key, PMIU_keyval_tab[i].value);
+}
+
+char *PMIU_getval( const char *keystr, char *valstr, int vallen )
+{
+    int i, rc;
+
+    for (i = 0; i < PMIU_keyval_tab_idx; i++) {
+	if ( strcmp( keystr, PMIU_keyval_tab[i].key ) == 0 ) {
+	    rc = MPIU_Strncpy( valstr, PMIU_keyval_tab[i].value, vallen );
+	    if (rc != 0) {
+		PMIU_printf( 1, "MPIU_Strncpy failed in PMIU_getval\n" );
+		return NULL;
+	    }
+	    return valstr;
+       }
+    }
+    valstr[0] = '\0';
+    return NULL;
+}
+
+void PMIU_chgval( const char *keystr, char *valstr )
+{
+    int i;
+
+    for ( i = 0; i < PMIU_keyval_tab_idx; i++ ) {
+	if ( strcmp( keystr, PMIU_keyval_tab[i].key ) == 0 ) {
+	    MPIU_Strncpy( PMIU_keyval_tab[i].value, valstr, MAXVALLEN - 1 );
+	    PMIU_keyval_tab[i].value[MAXVALLEN - 1] = '\0';
+	}
+    }
+}

--- a/shmem_pmi/simple_pmiutil.h
+++ b/shmem_pmi/simple_pmiutil.h
@@ -1,0 +1,64 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2001 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+/* maximum sizes for arrays */
+#define PMIU_MAXLINE 1024
+#define PMIU_IDSIZE    32
+
+#define MPIU_Snprintf(...)    \
+    ({ snprintf(__VA_ARGS__); \
+        0;                    \
+    })
+#define MPIU_Strncpy(...)                               \
+    ({ strncpy(__VA_ARGS__);                            \
+        0;                                              \
+    })
+#define MPIU_Exit     exit
+#define MPIU_Strnapp(...)                   \
+    ({ strncat(__VA_ARGS__);                \
+        0;                                  \
+    })
+#define ATTRIBUTE __attribute__
+#define MPI_MAX_PORT_NAME      256
+#define MAXHOSTNAME 256
+#define HAVE_ASSERT_H
+#define HAVE_ARPA_INET_H
+#define HAVE_SYS_TYPES_H
+#define HAVE_UNISTD_H
+#define HAVE_STDLIB_H
+#define HAVE_STRING_H
+#define HAVE_STRINGS_H
+#define USE_PMI_PORT
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+
+/* we don't have access to MPIU_Assert and friends here in the PMI code */
+#if defined(HAVE_ASSERT_H)
+#  include <assert.h>
+#  define PMIU_Assert(expr) assert(expr)
+#else
+#  define PMIU_Assert(expr)
+#endif
+
+#if defined HAVE_ARPA_INET_H
+#include <arpa/inet.h>
+#endif /* HAVE_ARPA_INET_H */
+
+
+
+
+
+/* prototypes for PMIU routines */
+void PMIU_Set_rank( int PMI_rank );
+void PMIU_SetServer( void );
+void PMIU_printf( int print_flag, const char *fmt, ... );
+int  PMIU_readline( int fd, char *buf, int max );
+int  PMIU_writeline( int fd, char *buf );
+int  PMIU_parse_keyvals( char *st );
+void PMIU_dump_keyvals( void );
+char *PMIU_getval( const char *keystr, char *valstr, int vallen );
+void PMIU_chgval( const char *keystr, char *valstr );


### PR DESCRIPTION
++built-in pmi support
Note on usage:
        build and install shmem_pmi before building shmem
        to use during shmem configuration add: --with-pmi=${PWD} --with-pmi-libdir=shmem_pmi
        ->the above will find your libshmem_pmi.so regardless of shmem_pmi's config prefix
	choosing shmem_pmi will assume mpiexec.hydra for make check (set env variables accordingly)
++if "with-ofi" isn't on configure line ofi will not be built

Signed-off-by: kseager <kayla.seager@intel.com>