### PR TITLE
shmem_pmi implementation update: --enable-pmi-simple

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,4 +13,4 @@ ACLOCAL_AMFLAGS = -I config
 
 EXTRA_DIST = README NEWS LICENSE
 
-SUBDIRS = mpp src test
+SUBDIRS = mpp $(SHMEM_PMI) src test

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,12 @@
+#! /bin/sh
+
+set -x
+test -d ./config || mkdir ./config
+aclocal -I config
+libtoolize --force --copy
+autoheader
+automake --foreign --add-missing --copy
+autoconf
+
+cd shmem_pmi
+./autogen.sh

--- a/config/orte_check_pmi.m4
+++ b/config/orte_check_pmi.m4
@@ -29,9 +29,7 @@ AC_DEFUN([ORTE_CHECK_PMI],[
     AC_ARG_WITH([pmi-libdir],
         [AC_HELP_STRING([--with-pmi-libdir=DIR],
              [Search for PMI libraries in DIR])])
-    AS_IF([test "$with_pmi_libdir" = "shmem_pmi"],
-        [OMPI_CHECK_WITHDIR([pmi-libdir], [install/lib], [libshmem_pmi.*])],
-        [OMPI_CHECK_WITHDIR([pmi-libdir], [$with_pmi_libdir], [libpmi.*])])
+    OMPI_CHECK_WITHDIR([pmi-libdir], [$with_pmi_libdir], [libpmi.*])
 
     orte_check_pmi_$1_save_CPPFLAGS="$CPPFLAGS"
     orte_check_pmi_$1_save_LDFLAGS="$LDFLAGS"
@@ -42,20 +40,7 @@ AC_DEFUN([ORTE_CHECK_PMI],[
     AS_IF([test ! -z "$with_pmi_libdir" -a "$with_pmi_libdir" != "yes"],
         [ompi_check_pmi_libdir="$with_pmi_libdir"])
 
-    AS_IF([test "$with_pmi_libdir" = "shmem_pmi"],
-        [OMPI_CHECK_PACKAGE([$1],
-                [${ompi_check_pmi_dir}/shmem_pmi/pmi.h],
-                [shmem_pmi],
-                [PMI_Init],
-                [],
-                [${ompi_check_pmi_dir}/shmem_pmi],
-                [${ompi_check_pmi_dir}/install/lib],
-                [AC_DEFINE([SHMEM_PMI], [1],
-                         [Using SHMEM PMI])
-                 TEST_RUNNER='mpiexec.hydra -n $(NPROCS)'
-                 ompi_check_pmi_happy="yes"],
-                 [ompi_check_pmi_happy="no"])],
-	[OMPI_CHECK_PACKAGE([$1],
+    OMPI_CHECK_PACKAGE([$1],
         [pmi.h],
         [pmi],
         [PMI_Init],
@@ -64,7 +49,7 @@ AC_DEFUN([ORTE_CHECK_PMI],[
         [$ompi_check_pmi_libdir],
         [TEST_RUNNER=''
          ompi_check_pmi_happy="yes"],
-		[ompi_check_pmi_happy="no"])])
+        [ompi_check_pmi_happy="no"])
     AS_IF([test "$ompi_check_pmi_happy" = "no"], 
         [OMPI_CHECK_PACKAGE([$1],
                 [slurm/pmi.h],

--- a/configure.ac
+++ b/configure.ac
@@ -171,7 +171,12 @@ AS_IF([test "transport_xpmem" = "yes" -o "$transport_cma" = "yes"],
 AS_IF([test "$transport_portals4" != "yes" -a "$transport_xpmem" != "yes" -a "$transport_cma" != "yes" -a "$transport_ofi" != "yes"],
       [AC_MSG_ERROR([No transport found])])
 
-ORTE_CHECK_PMI([pmi])
+AC_ARG_ENABLE([pmi-simple], [AC_HELP_STRING([--enable-pmi-simple],
+			[build and run shmem-pmi support])])
+AS_IF([test "$enable_pmi_simple" = "yes"],
+     [TEST_RUNNER='mpiexec.hydra -n $(NPROCS)' SHMEM_PMI="shmem_pmi"], [ORTE_CHECK_PMI([pmi]) SHMEM_PMI=""])
+AC_SUBST([SHMEM_PMI])
+AM_CONDITIONAL([USE_SHMEM_PMI], [test "$enable_pmi_simple" = "yes"])
 
 dnl check for header files
 
@@ -354,6 +359,8 @@ AC_CONFIG_FILES([Makefile
   test/openshmem/feature_tests/Fortran/transfer/Makefile
   test/openshmem/performance_tests/Makefile
   test/openshmem/performance_tests/micro_benchmarks/Makefile])
+AS_IF([test "$enable_pmi_simple" = "yes"],
+	[AC_CONFIG_SUBDIRS([shmem_pmi])])
 AC_OUTPUT
 
 FORT="$FC"

--- a/shmem_pmi/Makefile.am
+++ b/shmem_pmi/Makefile.am
@@ -7,7 +7,3 @@ libshmem_pmi_la_SOURCES = \
 	simple_pmiutil.c \
 	simple_pmiutil.h \
 	pmi.h
-
-install-exec-hook:
-	$(MKDIR_P) ../install/lib
-	$(LN_S) -f $(DESTDIR)$(libdir)/libshmem_pmi${shrext_cmds} ../install/lib/libshmem_pmi${shrext_cmds}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -82,6 +82,14 @@ libsma_la_SOURCES += \
 	transport_cma.c
 endif
 
+if USE_SHMEM_PMI
+AM_CPPFLAGS += -I$(top_srcdir)/shmem_pmi
+
+libsma_la_LIBADD = \
+	../shmem_pmi/simple_pmi.lo \
+	../shmem_pmi/simple_pmiutil.lo
+endif
+
 bin_SCRIPTS = oshcc oshc++
 CLEANFILES += oshcc oshc++
 if CASE_SENSITIVE_FS


### PR DESCRIPTION
New use case model for using shmem_pmi
-thanks Jim for the idea of adding the --enable-pmi-simple feature
-reinvisioned build implementation (removed old implementation)
        -if you use configure option shmem_pmi will be built in by default
        else you must use the old usage pattern for pmi support
note: added autogen.sh for ease of use
This closes #23
Signed-off-by: kseager <kayla.seager@intel.com>