### PR TITLE
Collectives update: new reduction algorithm for long double

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -205,7 +205,7 @@ AC_CHECK_SIZEOF([long double])
 AC_CHECK_SIZEOF([void*])
 
 C_BCAST_SYNC_SIZE=1
-C_REDUCE_SYNC_SIZE=`echo "$C_BCAST_SYNC_SIZE 2 + p" | dc`
+C_REDUCE_SYNC_SIZE=34
 C_BARRIER_SYNC_SIZE=`echo "$ac_cv_sizeof_int 8 * $ac_cv_sizeof_long / p" | dc`
 tree_sync_size=`echo "$C_BCAST_SYNC_SIZE 3 + p" | dc`
 recdbl_sync_size=`echo "$ac_cv_sizeof_int 8 * $ac_cv_sizeof_long / p" | dc`

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -41,7 +41,8 @@ libsma_la_SOURCES = \
 	synchronization_c.c \
 	collectives_c.c \
 	lock_c.c \
-	cache_management_c.c
+	cache_management_c.c \
+	op.h
 
 if HAVE_FORTRAN
 libsma_la_SOURCES += \

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -76,7 +76,7 @@ shmem_internal_collectives_init(int requested_crossover,
     shmem_internal_barrier_all_psync = 
         shmem_internal_shmalloc(sizeof(long) * _SHMEM_BARRIER_SYNC_SIZE);
     if (NULL == shmem_internal_barrier_all_psync) return -1;
-    bzero(shmem_internal_barrier_all_psync, sizeof(long) * _SHMEM_BARRIER_SYNC_SIZE);
+    memset(shmem_internal_barrier_all_psync, SHMEM_SYNC_VALUE,  sizeof(long) * _SHMEM_BARRIER_SYNC_SIZE);
 
     i = shmem_internal_num_pes;
     i >>= 1; /* base case: if 2 log2_proc is correct*/
@@ -792,7 +792,7 @@ shmem_internal_op_to_all_recdbl(void *target, void *source, int count, int type_
 	pSync[0] = _SHMEM_SYNC_VALUE;
 	pSync[1] = _SHMEM_SYNC_VALUE;
 	pSync[2] = _SHMEM_SYNC_VALUE;
-	bzero(shmem_internal_recdbl_psync, sizeof(int) * log2_proc);
+	memset(shmem_internal_recdbl_psync, SHMEM_SYNC_VALUE,  sizeof(int) * log2_proc);
 
 }
 

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -18,6 +18,7 @@
 #include "shmem_internal.h"
 #include "shmem_collectives.h"
 #include "shmem.h"
+#include "op.h"
 
 coll_type_t shmem_internal_barrier_type = AUTO;
 coll_type_t shmem_internal_bcast_type = AUTO;
@@ -25,6 +26,7 @@ coll_type_t shmem_internal_reduce_type = AUTO;
 coll_type_t shmem_internal_collect_type = AUTO;
 coll_type_t shmem_internal_fcollect_type = AUTO;
 long *shmem_internal_barrier_all_psync;
+int *shmem_internal_recdbl_psync;
 int shmem_internal_tree_crossover = -1;
 
 static int *full_tree_children;
@@ -65,6 +67,7 @@ shmem_internal_collectives_init(int requested_crossover,
     int tmp_radix;
     int my_root = 0;
     char *type;
+    int log2_proc = 1;
 
     tree_radix = requested_radix;
     shmem_internal_tree_crossover = requested_crossover;
@@ -73,7 +76,19 @@ shmem_internal_collectives_init(int requested_crossover,
     shmem_internal_barrier_all_psync = 
         shmem_internal_shmalloc(sizeof(long) * _SHMEM_BARRIER_SYNC_SIZE);
     if (NULL == shmem_internal_barrier_all_psync) return -1;
-    memset(shmem_internal_barrier_all_psync, 0, sizeof(long) * _SHMEM_BARRIER_SYNC_SIZE);
+    bzero(shmem_internal_barrier_all_psync, sizeof(long) * _SHMEM_BARRIER_SYNC_SIZE);
+
+    i = shmem_internal_num_pes;
+    i >>= 1; /* base case: if 2 log2_proc is correct*/
+    while (i != 1) {
+        i >>= 1;
+        log2_proc++;
+    }
+
+    shmem_internal_recdbl_psync =
+        (int *)shmem_internal_shmalloc(sizeof(int) * log2_proc);
+    if (NULL == shmem_internal_recdbl_psync) return -1;
+    bzero(shmem_internal_recdbl_psync, sizeof(int) * log2_proc);
 
     /* initialize the binomial tree for collective operations over
        entire tree */
@@ -638,6 +653,147 @@ shmem_internal_op_to_all_tree(void *target, void *source, int count, int type_si
     /* broadcast out */
     shmem_internal_bcast(target, target, count * type_size, 0, PE_start, 
                          logPE_stride, PE_size, pSync + 2, 0);
+}
+
+
+
+void
+shmem_internal_op_to_all_recdbl(void *target, void *source, int count, int type_size,
+                                int PE_start, int logPE_stride, int PE_size,
+                                void *pWrk, long *pSync,
+                                shm_internal_op_t op, shm_internal_datatype_t datatype)
+{
+	int stride = 1 << logPE_stride;
+	int my_id = ((shmem_internal_my_pe - PE_start) / stride);
+	long one = 1, neg_one = -1, buff = 0;
+	int log2_proc = 1, pow2_proc = 1;
+	int i = PE_size;
+	int wrk_size = type_size*count;
+	void * const current_target = malloc(wrk_size);
+	int peer = 0;
+	long completion = 0;
+
+ /***********************************
+ *
+ *	INPUT CHECKS AND VAR INIT
+ *
+ * **************************************/
+
+	i >>= 1; /* base case: if 2 pow2_proc is correct*/
+	pow2_proc <<= 1;
+
+	while (i != 1) {
+		i >>= 1;
+		pow2_proc <<= 1;
+		log2_proc++;
+	}
+
+	if (current_target)
+		memcpy(current_target, (void *) source, wrk_size);
+	else
+		RAISE_ERROR(1);
+
+ /***********************************
+ *
+ *	-target is used as "temp" buffer -- current_target tracks latest result
+ *	give partner current_result,
+ *
+ * **************************************/
+
+	for (i = 0; i < PE_size; i++) {
+		peer = PE_start + i*stride;
+		shmem_internal_atomic_small(pSync, &one, sizeof(long), peer,
+				SHM_INTERNAL_SUM, DTYPE_LONG);
+	}
+	shmem_internal_fence();
+	SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, PE_size);
+
+	/*extra peer exchange*/
+	if (my_id >= pow2_proc) {
+		peer = (my_id - pow2_proc) * stride + PE_start;
+		shmem_internal_put_nb(target, current_target, wrk_size, peer,
+					&completion);
+		shmem_internal_put_wait(&completion);
+		shmem_internal_fence();
+
+		buff = neg_one;
+		shmem_internal_put_small(&pSync[1], &buff, sizeof(long),
+				peer);
+		shmem_internal_fence();
+		buff = neg_one;
+		SHMEM_WAIT_UNTIL(&pSync[1], SHMEM_CMP_EQ, buff);
+
+	} else {
+		if ((PE_size - pow2_proc) > my_id) {
+			peer = (my_id + pow2_proc) * stride + PE_start;
+			buff = neg_one;
+			SHMEM_WAIT_UNTIL(&pSync[1], SHMEM_CMP_EQ, buff);
+
+			shmem_op_tls(op, datatype, count, target, current_target);
+		}
+
+		/* Pairwise exchange */
+
+		int *step_psync;
+
+		for (i = 0; i < log2_proc; i++) {
+
+			peer = (my_id ^ (1 << i)) * stride + PE_start;
+			step_psync = &shmem_internal_recdbl_psync[i];
+
+			if (my_id < peer) {
+				shmem_internal_put_small(step_psync, &one,
+						sizeof(int), peer);
+				SHMEM_WAIT(step_psync, 0);
+				shmem_internal_put_nb(target, current_target,
+						wrk_size, peer, &completion);
+				shmem_internal_put_wait(&completion);
+				shmem_internal_fence();
+				shmem_internal_atomic_small(step_psync, &one,
+						sizeof(int), peer,
+						SHM_INTERNAL_SUM, DTYPE_INT);
+			} else {
+				SHMEM_WAIT(step_psync, 0);
+				shmem_internal_put_nb(target, current_target,
+						wrk_size, peer, &completion);
+				shmem_internal_put_wait(&completion);
+				shmem_internal_fence();
+				shmem_internal_put_small(step_psync,
+					&one, sizeof(int), peer);
+				SHMEM_WAIT(step_psync, 1);
+			}
+
+			/* perform op */
+			shmem_op_tls(op, datatype, count, target, current_target);
+
+		}
+
+		shmem_internal_quiet();
+
+		/*extra peer update*/
+		if ((PE_size - pow2_proc) > my_id) {
+			peer = (my_id + pow2_proc) * stride + PE_start;
+
+			shmem_internal_put_nb(target, current_target, wrk_size,
+					peer, &completion);
+			shmem_internal_put_wait(&completion);
+			shmem_internal_fence();
+
+			buff = neg_one;
+			shmem_internal_put_small(&pSync[1], &buff,
+					sizeof(long), peer);
+			shmem_internal_fence();
+		}
+	}
+
+	memcpy(target, current_target, wrk_size);
+	free(current_target);
+
+	pSync[0] = _SHMEM_SYNC_VALUE;
+	pSync[1] = _SHMEM_SYNC_VALUE;
+	pSync[2] = _SHMEM_SYNC_VALUE;
+	bzero(shmem_internal_recdbl_psync, sizeof(int) * log2_proc);
+
 }
 
 

--- a/src/collectives_c.c
+++ b/src/collectives_c.c
@@ -392,9 +392,14 @@ shmem_longdouble_min_to_all(long double *target, long double *source, int nreduc
 {
     SHMEM_ERR_CHECK_INITIALIZED();
 
-    shmem_internal_op_to_all(target, source, nreduce, sizeof(long double),
+    if(!shmem_long_dub_supported) {
+	shmem_internal_op_to_all_recdbl(target, source, nreduce, sizeof(long double),
+			    PE_start, logPE_stride, PE_size, pWrk, pSync, SHM_INTERNAL_MIN, SHM_INTERNAL_LONG_DOUBLE);
+    } else {
+	shmem_internal_op_to_all(target, source, nreduce, sizeof(long double),
                     PE_start, logPE_stride, PE_size,
                     pWrk, pSync, SHM_INTERNAL_MIN, SHM_INTERNAL_LONG_DOUBLE);
+    }
 }
 
 
@@ -483,10 +488,16 @@ shmem_longdouble_max_to_all(long double *target, long double *source, int nreduc
 {
     SHMEM_ERR_CHECK_INITIALIZED();
 
-    shmem_internal_op_to_all(target, source, nreduce, sizeof(long double),
+    if(!shmem_long_dub_supported) {
+        shmem_internal_op_to_all_recdbl(target, source, nreduce, sizeof(long double),
+			    PE_start, logPE_stride, PE_size, pWrk, pSync, SHM_INTERNAL_MAX, SHM_INTERNAL_LONG_DOUBLE);
+    } else {
+	shmem_internal_op_to_all(target, source, nreduce, sizeof(long double),
                     PE_start, logPE_stride, PE_size,
                     pWrk, pSync, SHM_INTERNAL_MAX, SHM_INTERNAL_LONG_DOUBLE);
+    }
 }
+
 
 
 void
@@ -574,9 +585,14 @@ shmem_longdouble_sum_to_all(long double *target, long double *source, int nreduc
 {
     SHMEM_ERR_CHECK_INITIALIZED();
 
-    shmem_internal_op_to_all(target, source, nreduce, sizeof(long double),
+    if(!shmem_long_dub_supported) {
+	shmem_internal_op_to_all_recdbl(target, source, nreduce, sizeof(long double),
+			    PE_start, logPE_stride, PE_size, pWrk, pSync, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG_DOUBLE);
+    } else {
+	shmem_internal_op_to_all(target, source, nreduce, sizeof(long double),
                     PE_start, logPE_stride, PE_size,
                     pWrk, pSync, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG_DOUBLE);
+    }
 }
 
 
@@ -691,9 +707,14 @@ shmem_longdouble_prod_to_all(long double *target, long double *source, int nredu
 {
     SHMEM_ERR_CHECK_INITIALIZED();
 
-    shmem_internal_op_to_all(target, source, nreduce, sizeof(long double),
+    if(!shmem_long_dub_supported) {
+	shmem_internal_op_to_all_recdbl(target, source, nreduce, sizeof(long double),
+			    PE_start, logPE_stride, PE_size, pWrk, pSync, SHM_INTERNAL_PROD, SHM_INTERNAL_LONG_DOUBLE);
+    } else {
+	shmem_internal_op_to_all(target, source, nreduce, sizeof(long double),
                     PE_start, logPE_stride, PE_size,
                     pWrk, pSync, SHM_INTERNAL_PROD, SHM_INTERNAL_LONG_DOUBLE);
+    }
 }
 
 

--- a/src/init.c
+++ b/src/init.c
@@ -51,6 +51,8 @@ int shmem_internal_finalized = 0;
 int shmem_internal_initialized_with_start_pes = 0;
 int shmem_internal_global_exit_called = 0;
 
+int shmem_long_dub_supported = 1;
+
 int shmem_internal_thread_level;
 
 #ifdef ENABLE_THREADS

--- a/src/op.h
+++ b/src/op.h
@@ -1,0 +1,77 @@
+/* -*- C -*-
+ *
+ * Copyright 2011 Sandia Corporation. Under the terms of Contract
+ * DE-AC04-94AL85000 with Sandia Corporation, the U.S.  Government
+ * retains certain rights in this software.
+ *
+ * Copyright (c) 2015 Intel Corporation. All rights reserved.
+ * This software is available to you under the BSD license.
+ *
+ * Copyright (c) 2013 Mellanox Technologies, Inc. All rights reserved.
+ *
+ * Copyright (c) 2013 Cisco Systems, Inc.  All rights reserved.
+ *
+ * This file is part of the Portals SHMEM software package. For license
+ * information, see the LICENSE file in the top level directory of the
+ * distribution.
+ *
+ */
+
+#define FUNC_OP_CREATE(name, type_name, type, calc)  \
+    void shmem_op_##name##_##type_name##_func(void *in, void *out, int count); \
+    void shmem_op_##name##_##type_name##_func(void *in, void *out, int count) \
+    {                                                                       \
+        int i;                                                              \
+        type *a = (type *) in;                                              \
+        type *b = (type *) out;                                             \
+        for (i = 0; i < count; ++i) {                                       \
+            *(b) = calc(*(b), *(a));                                        \
+            ++b;                                                            \
+            ++a;                                                            \
+        }                                                                   \
+    }
+
+
+ #define FUNC_CALL(op_name, type_name, in, out, count) \
+	shmem_op_##op_name##_##type_name##_func(in, out, count); \
+
+
+
+/* MAX */
+#define __max_op(a, b) ((a) > (b) ? (a) : (b))
+FUNC_OP_CREATE(max, longdouble, long double, __max_op)
+
+/* MIN */
+#define __min_op(a, b) ((a) < (b) ? (a) : (b))
+FUNC_OP_CREATE(min, longdouble, long double, __min_op)
+
+/* SUM */
+#define __sum_op(a, b) ((a) + (b))
+FUNC_OP_CREATE(sum, longdouble, long double, __sum_op)
+
+/* PROD */
+#define __prod_op(a, b) ((a) * (b))
+FUNC_OP_CREATE(prod, longdouble, long double, __prod_op)
+
+/*simple implementation: DT_CMPxOPS, DT_INTxBOPS */
+void static inline shmem_op_tls(shm_internal_op_t op, shm_internal_datatype_t datatype,
+			int count, void * target, void* current_target) {
+
+	switch(op) {
+	case SHM_INTERNAL_MIN:
+		FUNC_CALL(min, longdouble, (long double *) target, (long double *) current_target, count);
+		break;
+	case SHM_INTERNAL_MAX:
+		FUNC_CALL(max, longdouble, (long double *) target, (long double *) current_target, count);
+		break;
+	case SHM_INTERNAL_SUM:
+		FUNC_CALL(sum, longdouble, (long double *) target, (long double *) current_target, count);
+		break;
+	case SHM_INTERNAL_PROD:
+		FUNC_CALL(prod, longdouble, (long double *) target, (long double *) current_target, count);
+		break;
+	default:
+		fprintf(stderr,"op type not supported =( \n");
+		exit(1);
+	}
+}

--- a/src/op.h
+++ b/src/op.h
@@ -17,41 +17,35 @@
  *
  */
 
-#define FUNC_OP_CREATE(name, type_name, type, calc)  \
-    void shmem_op_##name##_##type_name##_func(void *in, void *out, int count); \
-    void shmem_op_##name##_##type_name##_func(void *in, void *out, int count) \
+#define FUNC_OP_CREATE(name, calc)  \
+    void static shmem_op_##name##_func(long double *in, long double *out, int count); \
+    void static shmem_op_##name##_func(long double *in, long double *out, int count) \
     {                                                                       \
         int i;                                                              \
-        type *a = (type *) in;                                              \
-        type *b = (type *) out;                                             \
         for (i = 0; i < count; ++i) {                                       \
-            *(b) = calc(*(b), *(a));                                        \
-            ++b;                                                            \
-            ++a;                                                            \
+            *(out) = calc(*(out), *(in));                                   \
+            ++out;                                                          \
+            ++in;                                                           \
         }                                                                   \
     }
 
 
- #define FUNC_CALL(op_name, type_name, in, out, count) \
-	shmem_op_##op_name##_##type_name##_func(in, out, count); \
-
-
-
 /* MAX */
-#define __max_op(a, b) ((a) > (b) ? (a) : (b))
-FUNC_OP_CREATE(max, longdouble, long double, __max_op)
+#define shmem_internal_max_op(a, b) ((a) > (b) ? (a) : (b))
+FUNC_OP_CREATE(max, shmem_internal_max_op)
 
 /* MIN */
-#define __min_op(a, b) ((a) < (b) ? (a) : (b))
-FUNC_OP_CREATE(min, longdouble, long double, __min_op)
+#define shmem_internal_min_op(a, b) ((a) < (b) ? (a) : (b))
+FUNC_OP_CREATE(min, shmem_internal_min_op)
 
 /* SUM */
-#define __sum_op(a, b) ((a) + (b))
-FUNC_OP_CREATE(sum, longdouble, long double, __sum_op)
+#define shmem_internal_sum_op(a, b) ((a) + (b))
+FUNC_OP_CREATE(sum, shmem_internal_sum_op)
 
 /* PROD */
-#define __prod_op(a, b) ((a) * (b))
-FUNC_OP_CREATE(prod, longdouble, long double, __prod_op)
+#define shmem_internal_prod_op(a, b) ((a) * (b))
+FUNC_OP_CREATE(prod, shmem_internal_prod_op)
+
 
 /*simple implementation: DT_CMPxOPS, DT_INTxBOPS */
 void static inline shmem_op_tls(shm_internal_op_t op, shm_internal_datatype_t datatype,
@@ -59,19 +53,19 @@ void static inline shmem_op_tls(shm_internal_op_t op, shm_internal_datatype_t da
 
 	switch(op) {
 	case SHM_INTERNAL_MIN:
-		FUNC_CALL(min, longdouble, (long double *) target, (long double *) current_target, count);
+		shmem_op_min_func((long double *) target, (long double *) current_target, count);
 		break;
 	case SHM_INTERNAL_MAX:
-		FUNC_CALL(max, longdouble, (long double *) target, (long double *) current_target, count);
+		shmem_op_max_func((long double *) target, (long double *) current_target, count);
 		break;
 	case SHM_INTERNAL_SUM:
-		FUNC_CALL(sum, longdouble, (long double *) target, (long double *) current_target, count);
+		shmem_op_sum_func((long double *) target, (long double *) current_target, count);
 		break;
 	case SHM_INTERNAL_PROD:
-		FUNC_CALL(prod, longdouble, (long double *) target, (long double *) current_target, count);
+		shmem_op_prod_func((long double *) target, (long double *) current_target, count);
 		break;
 	default:
 		fprintf(stderr,"op type not supported =( \n");
-		exit(1);
+		RAISE_ERROR(1);
 	}
 }

--- a/src/shmem_collectives.h
+++ b/src/shmem_collectives.h
@@ -129,6 +129,11 @@ void shmem_internal_op_to_all_tree(void *target, void *source, int count, int ty
                                    void *pWrk, long *pSync, 
                                    shm_internal_op_t op, shm_internal_datatype_t datatype);
 
+void shmem_internal_op_to_all_recdbl(void *target, void *source, int count, int type_size,
+                                   int PE_start, int logPE_stride, int PE_size,
+                                   void *pWrk, long *pSync,
+                                   shm_internal_op_t op, shm_internal_datatype_t datatype);
+
 static inline
 void
 shmem_internal_op_to_all(void *target, void *source, int count, int type_size,
@@ -158,6 +163,11 @@ shmem_internal_op_to_all(void *target, void *source, int count, int type_size,
                                       PE_start, logPE_stride, PE_size,
                                       pWrk, pSync, op, datatype);
         break;
+    case RECDBL:
+        shmem_internal_op_to_all_recdbl(target, source, count, type_size,
+                                      PE_start, logPE_stride, PE_size,
+                                      pWrk, pSync, op, datatype);
+	break;
     default:
         fprintf(stderr, "[%03d] Illegal reduction type %d\n", 
                 shmem_internal_my_pe, shmem_internal_reduce_type);

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -28,6 +28,8 @@ extern int shmem_internal_initialized;
 extern int shmem_internal_finalized;
 extern int shmem_internal_thread_level;
 
+extern int shmem_long_dub_supported;
+
 #define RAISE_ERROR(ret)                                                \
     do {                                                                \
         fprintf(stderr, "[%03d] ERROR: %s:%d return code %d\n",         \

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -334,7 +334,7 @@ static inline void atomic_limitations_check(void)
     }
 
     /* OTHER OPS check */
-    for(i=0; i<6; i++) {//DT
+    for(i=0; i<5; i++) {//DT
       for(j=0; j<4; j++) { //OPS
         ret = fi_atomicvalid(shmem_transport_ofi_epfd, SHM_DT_CMP[i], SHM_OPS[j],
                         &atomic_size);

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -72,7 +72,7 @@ static int SHM_DT_INT[]=
 static int SHM_DT_CMP[]=
 {
   DTYPE_SHORT, DTYPE_INT, DTYPE_LONG,
-  SHM_INTERNAL_FLOAT, SHM_INTERNAL_DOUBLE, SHM_INTERNAL_LONG_DOUBLE,
+  SHM_INTERNAL_FLOAT, SHM_INTERNAL_DOUBLE
 };
 
 static int SHM_BOPS[]=
@@ -345,6 +345,14 @@ static inline void atomic_limitations_check(void)
       }
     }
 
+    /* LONG DOUBLE limitation is common */
+    for(j=0; j<4; j++) { //OPS
+        ret = fi_atomicvalid(shmem_transport_ofi_epfd, SHM_INTERNAL_LONG_DOUBLE, SHM_OPS[j], &atomic_size);
+        if(ret!=0 || atomic_size == 0) {
+		shmem_long_dub_supported = 0;
+		break;
+	}
+    }
 
 }
 


### PR DESCRIPTION
some providers can't support long double; as a result,
enable SHMEM-OFI to detect the limitation and change algorithms accordingly.
By default, long double support is assumed.
new file op.h: long double software atomic support

Signed-off-by: kseager <kayla.seager@intel.com>