### PR TITLE
Fix for global_exit

### DIFF
--- a/shmem_pmi/simple_pmi.c
+++ b/shmem_pmi/simple_pmi.c
@@ -314,14 +314,21 @@ int PMI_Finalize( void )
 
 int PMI_Abort(int exit_code, const char error_msg[])
 {
-    PMIU_printf(1, "aborting job:\n%s\n", error_msg);
-    MPIU_Exit(exit_code);
+    char buf[PMIU_MAXLINE];
+
+    /* include exit_code in the abort command */
+    MPIU_Snprintf( buf, PMIU_MAXLINE, "cmd=abort exitcode=%d\n", exit_code);
+
+    PMIU_printf(PMI_debug, "aborting job:\n%s\n", error_msg);
+    GetResponse( buf, "", 0 );
+
+    /* the above command should not return */
     return -1;
 }
 
 /************************************* Keymap functions **********************/
 
-/*FIXME: need to return an error if the value of the kvs name returned is
+/*FIXME: need to return an error if the value of the kvs name returned is 
   truncated because it is larger than length */
 /* FIXME: My name should be cached rather than re-acquired, as it is
    unchanging (after singleton init) */

--- a/src/init.c
+++ b/src/init.c
@@ -133,6 +133,8 @@ shmem_internal_shutdown(void)
     }
     shmem_internal_finalized = 1;
 
+    shmem_runtime_barrier();
+
     shmem_transport_fini();
 
 #ifdef USE_XPMEM

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -9,8 +9,7 @@
 # distribution.
 #
 
-check_PROGRAMS = $(TESTS) \
-		 global_exit ## Disabled; currently hangs
+check_PROGRAMS = $(TESTS)
 
 TESTS = \
 	hello \
@@ -58,7 +57,8 @@ TESTS = \
 	bcast_flood \
 	lfinc \
 	mt_a2a \
-	shmem_info
+	shmem_info \
+	global_exit
 
 if USE_PORTALS4
 TESTS += \


### PR DESCRIPTION
This closes issue #57.

Patch 2f8c4be should also be applied to Portals 4, and the version of hydra included with Portals 4 needs to also be updated to include support for the new PMI abort command. This looks like it could be tricky, because it looks like there are local changes to Hydra in the Portals 4 repository. In the meantime, we can build Portals 4 without PMI support and use the PMI support from Sandia-SHMEM with an external launcher.