### PR TITLE
Updates to improve coverage of CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -186,9 +186,8 @@ script:
     - grep -qi "Solution validates" stencil.log
     - mpiexec.hydra -np 4 ./SHMEM/Synch_p2p/p2p 10 1000 1000 2>&1 | tee p2p.log
     - grep -qi "Solution validates" p2p.log
-    ## Transpose is currently broken
-    #- mpiexec.hydra -np 4 ./SHMEM/Transpose/transpose 10 1000 2>&1 | tee transpose.log
-    #- grep -qi "Solution validates" transpose.log
+    - mpiexec.hydra -np 4 ./SHMEM/Transpose/transpose 10 1000 2>&1 | tee transpose.log
+    - grep -qi "Solution validates" transpose.log
     - make clean
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -182,9 +182,8 @@ script:
     - export OSHRUN_LAUNCHER="mpiexec.hydra"
     - cd $TRAVIS_SRC/PRK
     - make LIBS="-lm" allshmem
-    ## Stencil is currently broken
-    #- mpiexec.hydra -np 4 ./SHMEM/Stencil/stencil 100 1000 2>&1 | tee stencil.log
-    #- grep -qi "Solution validates" stencil.log
+    - mpiexec.hydra -np 4 ./SHMEM/Stencil/stencil 100 1000 2>&1 | tee stencil.log
+    - grep -qi "Solution validates" stencil.log
     - mpiexec.hydra -np 4 ./SHMEM/Synch_p2p/p2p 10 1000 1000 2>&1 | tee p2p.log
     - grep -qi "Solution validates" p2p.log
     ## Transpose is currently broken

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,25 @@ language: c
 compiler:
     #- clang
     - gcc
+env:
+    - SMA_BOUNCE_SIZE=0
+    - SMA_BARRIER_ALGORITHM=auto
+    - SMA_BARRIER_ALGORITHM=linear
+    - SMA_BARRIER_ALGORITHM=tree
+    - SMA_BARRIER_ALGORITHM=dissem
+    - SMA_BCAST_ALGORITHM=auto
+    - SMA_BCAST_ALGORITHM=linear
+    - SMA_BCAST_ALGORITHM=tree
+    - SMA_REDUCE_ALGORITHM=auto
+    - SMA_REDUCE_ALGORITHM=recdbl
+    - SMA_REDUCE_ALGORITHM=linear
+    - SMA_REDUCE_ALGORITHM=tree
+    - SMA_COLLECT_ALGORITHM=auto
+    - SMA_COLLECT_ALGORITHM=linear
+    - SMA_FCOLLECT_ALGORITHM=auto
+    - SMA_FCOLLECT_ALGORITHM=linear
+    - SMA_FCOLLECT_ALGORITHM=ring
+    - SMA_FCOLLECT_ALGORITHM=recdbl
 os:
     - linux
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ compiler:
     - gcc
 env:
     - SMA_BOUNCE_SIZE=0
+    - SMA_BOUNCE_SIZE=8
     - SMA_BARRIER_ALGORITHM=auto
     - SMA_BARRIER_ALGORITHM=linear
     - SMA_BARRIER_ALGORITHM=tree

--- a/README
+++ b/README
@@ -139,7 +139,7 @@ options.
     SMA_REDUCE_ALGORITHM (default: auto)
         Algorithm to use for reductions.  Default is to auto-select (which
         may result in different algorithms being used for different 
-        PE sets).  Options are: auto, linear, tree.
+        PE sets).  Options are: auto, linear, tree, recdbl.
 
     SMA_COLLECT_ALGORITHM (default: auto)
         Algorithm to use for allgathers.  Default is to auto-select (which

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -551,8 +551,6 @@ int shmem_transport_init(long eager_size)
     if(ret!=0)
 	return ret;
 
-    assert(eager_size > p_info->tx_attr->inject_size);
-
     shmem_transport_ofi_bounce_buffer_size = eager_size;
 
     //init LL for NB buffers


### PR DESCRIPTION
* Populate build matrix with env vars
* I contributed bugfixes to PRK, which allows us to re-enable those tests
* Remove assertion from OFI to enable disabling of bounce buffers