### PR TITLE
add rpath option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -107,6 +107,12 @@ AC_ARG_ENABLE([libtool-wrapper],
 AS_IF([test "$enable_libtool_wrapper" = "no"], [LIBTOOL_WRAPPER_LDFLAGS="-no-install"], [LIBTOOL_WRAPPER_LDFLAGS=])
 AC_SUBST([LIBTOOL_WRAPPER_LDFLAGS])
 
+AC_ARG_ENABLE([wrapper-rpath],
+  [AS_HELP_STRING([--enable-wrapper-rpath],
+    [Enable use of libtool executable wrappers for tests (default: disabled)])])
+AS_IF([test "$enable_wrapper_rpath" = "yes"], [RPATH_LDFLAGS="-Wl,-rpath -Wl,$libdir"], [RPATH_LDFLAGS=])
+AC_SUBST([ENABLE_WRAPPER_RPATH])
+
 
 AC_ARG_ENABLE([profiling],
     [AC_HELP_STRING([--enable-profiling],
@@ -339,11 +345,11 @@ AC_SUBST(CLEANFILES)
 # last minute updates of the flags so that tests don't fail oddly if
 # portals libdir isn't in LD_LIBRARY_PATH...
 CPPFLAGS="$CPPFLAGS $portals4_CPPFLAGS $ofi_CPPFLAGS $XPMEM_CPPFLAGS $pmi_CPPFLAGS"
-LDFLAGS="$LDFLAGS $portals4_LDFLAGS $ofi_LDFLAGS $XPMEM_LDFLAGS $pmi_LDFLAGS $aslr_LDFLAGS"
+LDFLAGS="$LDFLAGS $portals4_LDFLAGS $ofi_LDFLAGS $XPMEM_LDFLAGS $pmi_LDFLAGS $aslr_LDFLAGS $RPATH_LDFLAGS"
 LIBS="$LIBS $portals4_LIBS $ofi_LIBS $XPMEM_LIBS $pmi_LIBS"
 
 # wrapper compiler gorp
-WRAPPER_COMPILER_EXTRA_LDFLAGS="$portals4_LDFLAGS $ofi_LDFLAGS $XPMEM_LDFLAGS $pmi_LDFLAGS $aslr_LDFLAGS"
+WRAPPER_COMPILER_EXTRA_LDFLAGS="$portals4_LDFLAGS $ofi_LDFLAGS $XPMEM_LDFLAGS $pmi_LDFLAGS $aslr_LDFLAGS $RPATH_LDFLAGS"
 WRAPPER_COMPILER_EXTRA_LIBS="$portals4_LIBS $ofi_LIBS $XPMEM_LIBS $pmi_LIBS"
 AC_SUBST(WRAPPER_COMPILER_EXTRA_LDFLAGS)
 AC_SUBST(WRAPPER_COMPILER_EXTRA_LIBS)


### PR DESCRIPTION
This adds `-Wl,-rpath -Wl,$libdir` to the wrapper LDFLAGS so that one need not set `LD_LIBRARY_PATH` for SOS libraries in order to use them.

This is convenient if one intends to have multiple installs of SOS and rely upon the uniqueness of their respective wrappers to get the right shared library.

This does not rpath libfabric.  I think I can add that later, as an option to `--enable-wrapper-rpath`.