### PR TITLE
Fix error handling in mmap symmetric heap setup

### DIFF
--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -99,6 +99,7 @@ static void *mmap_alloc(size_t bytes)
                0);
     if (ret == MAP_FAILED) {
         perror("mmap()");
+        return NULL;
     }
     return ret;
 }


### PR DESCRIPTION
Error checks expect NULL when symmetric heap setup fails.  Return NULL
```((void*) 0)``` instead of MAP_FAILED ```((void*) -1)``` when mmap setup method
fails.

Signed-off-by: James Dinan <james.dinan@intel.com>