### PR TITLE
Add test for asymmetric allocation

### DIFF
--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -58,7 +58,8 @@ TESTS = \
 	lfinc \
 	mt_a2a \
 	shmem_info \
-	global_exit
+	global_exit \
+	asym_alloc
 
 if USE_PORTALS4
 TESTS += \
@@ -228,3 +229,6 @@ shmem_info_LDADD = $(top_builddir)/src/libsma.la
 
 shmem_info_f_SOURCES = shmem_info_f.f90
 shmem_info_f_LDADD = $(top_builddir)/src/libsma.la
+
+asym_alloc_SOURCES = asym_alloc.c
+asym_alloc_LDADD = $(top_builddir)/src/libsma.la

--- a/test/unit/asym_alloc.c
+++ b/test/unit/asym_alloc.c
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (c) 2016 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* Synopsis: Test that a single asymmetric allocation works correctly.
+ *
+ * This semantic is provided in OpenSHMEM 1.1 and some versions of Cray SHMEM.
+ * It was removed from OpenSHMEM in 1.2, but we maintain it for backward
+ * compatibility.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <shmem.h>
+
+long ps[SHMEM_REDUCE_SYNC_SIZE];
+long pw[SHMEM_REDUCE_MIN_WRKDATA_SIZE];
+long bufsize, maxbufsize;
+
+int main(int argc, char **argv) {
+    int *buf, *buf_in;
+    int me, npes, i, target;
+
+    shmem_init();
+    me = shmem_my_pe();
+    npes = shmem_n_pes();
+
+    /* Each PE allocates space for "me + 1" integers */
+    bufsize = me + 1;
+    buf = shmem_malloc(sizeof(int) * bufsize);
+
+    if (NULL == buf)
+        shmem_global_exit(1);
+
+    for (i = 0; i < bufsize; i++)
+        buf[i] = -1;
+
+    shmem_barrier_all();
+
+    /* Write to neighbor's buffer */
+    target = (me + 1) % npes;
+    buf_in = malloc(sizeof(int) * (target + 1));
+
+    for (i = 0; i < target + 1; i++)
+        buf_in[i] = target;
+
+    shmem_int_put(buf, buf_in, target + 1, target);
+
+    shmem_barrier_all();
+
+    /* Validate data was written correctly */
+    for (i = 0; i < me + 1; i++) {
+        if (buf[i] != me) {
+            printf("Error [%3d]: buf[%d] == %d, expected %d\n", me, i, buf[i], me);
+            shmem_global_exit(2);
+        }
+    }
+
+    free(buf_in);
+    shmem_free(buf);
+    shmem_finalize();
+    return 0;
+}


### PR DESCRIPTION
Backward compatibility test to check that the OpenSHMEM 1.1 asymmetric
memory allocation semantic works properly.

Signed-off-by: James Dinan <james.dinan@intel.com>