### PR TITLE
Fix races in shmem_lock_set/clear

### DIFF
--- a/src/shmem_lock.h
+++ b/src/shmem_lock.h
@@ -44,12 +44,19 @@ shmem_internal_clear_lock(long *lockp)
     cond = shmem_internal_my_pe + 1;
     shmem_internal_cswap(&(lock->last), &zero, &curr, &cond, sizeof(int), 0, DTYPE_INT);
     shmem_internal_get_wait();
+
     /* if local PE was not the last to hold the lock, have to look for the next in line */
     if (curr != shmem_internal_my_pe + 1) {
         /* wait for next part of the data block to be non-zero */
-        while (NEXT(lock->data) == 0) {
-            shmem_int_wait(&(lock->data), SIGNAL(lock->data));
+        for (;;) {
+            lock_t lock_cur = *lock;
+
+            if (NEXT(lock_cur.data) != 0)
+                break;
+
+            shmem_int_wait(&(lock->data), lock_cur.data);
         }
+
         /* set the signal bit on new lock holder */
         shmem_internal_mswap(&(lock->data), &sig, &curr, &sig, sizeof(int), NEXT(lock->data) - 1, DTYPE_INT);
         shmem_internal_get_wait();
@@ -75,8 +82,13 @@ shmem_internal_set_lock(long *lockp)
         shmem_internal_mswap(&(lock->data), &me, &curr, &next_mask, sizeof(int), curr - 1, DTYPE_INT);
         shmem_internal_get_wait();
         /* now wait for the signal part of data to be non-zero */
-        while (SIGNAL(lock->data) == 0) {
-            shmem_int_wait(&(lock->data), NEXT(lock->data));
+        for (;;) {
+            lock_t lock_cur = *lock;
+
+            if (SIGNAL(lock_cur.data) != 0)
+                break;
+
+            shmem_int_wait(&(lock->data), lock_cur.data);
         }
     }
 }


### PR DESCRIPTION
Correct races in set_lock and clear_lock that occurred in the sequence
(1) check if lock object was updated (2) else wait for update.  In the
second step, the lock object was re-read rather than using the value
read in the first step.  As a result, if an update arrived between
steps, shmem_lock_clear could wait using the new value as the wait
condition, resulting in a deadlock.

This should close issue #77.

Signed-off-by: James Dinan <james.dinan@intel.com>