### PR TITLE
Drop LIBS setting workaround in PRK build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -167,7 +167,7 @@ script:
     - export PATH=$TRAVIS_INSTALL/portals4/bin:$TRAVIS_INSTALL/sandia-shmem-portals4/bin:$TRAVIS_INSTALL/hydra/bin:$BASE_PATH
     - export OSHRUN_LAUNCHER="mpiexec.hydra"
     - cd $TRAVIS_SRC/PRK
-    - make LIBS="-lm" allshmem
+    - make allshmem
     - make clean
     ###
     ### Run PRK (OFI)
@@ -175,7 +175,7 @@ script:
     - export PATH=$TRAVIS_INSTALL/sandia-shmem-ofi/bin:$TRAVIS_INSTALL/hydra/bin:$BASE_PATH
     - export OSHRUN_LAUNCHER="mpiexec.hydra"
     - cd $TRAVIS_SRC/PRK
-    - make LIBS="-lm" allshmem
+    - make allshmem
     - mpiexec.hydra -np 4 ./SHMEM/Stencil/stencil 100 1000 2>&1 | tee stencil.log
     - grep -qi "Solution validates" stencil.log
     - mpiexec.hydra -np 4 ./SHMEM/Synch_p2p/p2p 10 1000 1000 2>&1 | tee p2p.log


### PR DESCRIPTION
Upstream dropped -lshmem from the default LIBS, rendering this
workaround unnecessary.

Signed-off-by: James Dinan <james.dinan@intel.com>