### PR TITLE
look for mpirun before mpiexec

### DIFF
--- a/src/shmem_launcher_script.in
+++ b/src/shmem_launcher_script.in
@@ -11,7 +11,7 @@
 # information, see the LICENSE file in the top level directory of the
 # distribution.
 
-SEARCH_LAUNCHERS="yod mpiexec mpirun srun"
+SEARCH_LAUNCHERS="yod mpirun mpiexec srun"
 LAUNCHER=""
 
 # Users can set the OSHRUN_LAUNCHER environment variable to specify the command


### PR DESCRIPTION
...because Intel MPI provides MPD-based mpiexec.

Intel MPI uses gawdawful MPD by default for mpiexec.  On machines where mpiexec is in the path, this leads to very sad pandas, because all the tests fail.