### PR TITLE
Fix errors in the profiling interface

### DIFF
--- a/src/accessibility_c.c
+++ b/src/accessibility_c.c
@@ -20,6 +20,7 @@
 #include "shmem_accessibility.h"
 
 #ifdef ENABLE_PROFILING
+#include "pshmem.h"
 
 #pragma weak shmem_pe_accessible = pshmem_pe_accessible
 #define shmem_pe_accessible pshmem_pe_accessible

--- a/src/atomic_c.c
+++ b/src/atomic_c.c
@@ -20,6 +20,7 @@
 #include "shmem_comm.h"
 
 #ifdef ENABLE_PROFILING
+#include "pshmem.h"
 
 #pragma weak shmem_float_swap = pshmem_float_swap
 #define shmem_float_swap pshmem_float_swap

--- a/src/cache_management_c.c
+++ b/src/cache_management_c.c
@@ -15,6 +15,28 @@
 #include "shmem.h"
 #include "shmem_internal.h"
 
+#ifdef ENABLE_PROFILING
+#include "pshmem.h"
+
+#pragma weak shmem_clear_cache_inv = pshmem_clear_cache_inv
+#define shmem_clear_cache_inv pshmem_clear_cache_inv
+
+#pragma weak shmem_clear_cache_line_inv = pshmem_clear_cache_line_inv
+#define shmem_clear_cache_line_inv pshmem_clear_cache_line_inv
+
+#pragma weak shmem_set_cache_inv = pshmem_set_cache_inv
+#define shmem_set_cache_inv pshmem_set_cache_inv
+
+#pragma weak shmem_set_cache_line_inv = pshmem_set_cache_line_inv
+#define shmem_set_cache_line_inv pshmem_set_cache_line_inv
+
+#pragma weak shmem_udcflush = pshmem_udcflush
+#define shmem_udcflush pshmem_udcflush
+
+#pragma weak shmem_udcflush_line = pshmem_udcflush_line
+#define shmem_udcflush_line pshmem_udcflush_line
+
+#endif /* ENABLE_PROFILING */
 
 void
 shmem_clear_cache_inv(void)

--- a/src/collectives_c.c
+++ b/src/collectives_c.c
@@ -26,6 +26,7 @@
 #include "shmem_collectives.h"
 
 #ifdef ENABLE_PROFILING
+#include "pshmem.h"
 
 #pragma weak shmem_barrier_all = pshmem_barrier_all
 #define shmem_barrier_all pshmem_barrier_all

--- a/src/data_c.c
+++ b/src/data_c.c
@@ -22,6 +22,7 @@
 #include "shmem_comm.h"
 
 #ifdef ENABLE_PROFILING
+#include "pshmem.h"
 
 #pragma weak shmem_float_p = pshmem_float_p
 #define shmem_float_p pshmem_float_p

--- a/src/data_c.c
+++ b/src/data_c.c
@@ -138,9 +138,6 @@
 #pragma weak shmem_getmem = pshmem_getmem
 #define shmem_getmem pshmem_getmem
 
-#pragma weak shmemx_getmem_ct = pshmemx_getmem_ct
-#define shmemx_getmem_ct pshmemx_getmem_ct
-
 #pragma weak shmem_float_iput = pshmem_float_iput
 #define shmem_float_iput pshmem_float_iput
 
@@ -204,20 +201,23 @@
 #pragma weak shmemx_putmem_ct = pshmemx_putmem_ct
 #define shmemx_putmem_ct pshmemx_putmem_ct
 
-#pragma weak shmemx_ct_create = pshmem_ct_create
-#define shmemx_ct_create pshmem_ct_create
+#pragma weak shmemx_getmem_ct = pshmemx_getmem_ct
+#define shmemx_getmem_ct pshmemx_getmem_ct
 
-#pragma weak shmemx_ct_free = pshmem_ct_free
-#define shmemx_ct_free pshmem_ct_free
+#pragma weak shmemx_ct_create = pshmemx_ct_create
+#define shmemx_ct_create pshmemx_ct_create
 
-#pragma weak shmemx_ct_get = pshmem_ct_get
-#define shmemx_ct_get pshmem_ct_get
+#pragma weak shmemx_ct_free = pshmemx_ct_free
+#define shmemx_ct_free pshmemx_ct_free
 
-#pragma weak shmemx_ct_set = pshmem_ct_set
-#define shmemx_ct_set pshmem_ct_set
+#pragma weak shmemx_ct_get = pshmemx_ct_get
+#define shmemx_ct_get pshmemx_ct_get
 
-#pragma weak shmemx_ct_wait = pshmem_ct_wait
-#define shmemx_ct_wait pshmem_ct_wait
+#pragma weak shmemx_ct_set = pshmemx_ct_set
+#define shmemx_ct_set pshmemx_ct_set
+
+#pragma weak shmemx_ct_wait = pshmemx_ct_wait
+#define shmemx_ct_wait pshmemx_ct_wait
 
 #endif /* ENABLE_PROFILING */
 

--- a/src/init_c.c
+++ b/src/init_c.c
@@ -18,6 +18,7 @@
 #include "shmem_internal.h"
 
 #ifdef ENABLE_PROFILING
+#include "pshmem.h"
 
 #pragma weak start_pes = pstart_pes
 #define start_pes pstart_pes

--- a/src/lock_c.c
+++ b/src/lock_c.c
@@ -20,6 +20,7 @@
 #include "shmem_lock.h"
 
 #ifdef ENABLE_PROFILING
+#include "pshmem.h"
 
 #pragma weak shmem_clear_lock = pshmem_clear_lock
 #define shmem_clear_lock pshmem_clear_lock

--- a/src/query_c.c
+++ b/src/query_c.c
@@ -21,6 +21,7 @@
 #include "shmem_internal.h"
 
 #ifdef ENABLE_PROFILING
+#include "pshmem.h"
 
 #pragma weak _num_pes = p_num_pes
 #define _num_pes p_num_pes

--- a/src/remote_pointer_c.c
+++ b/src/remote_pointer_c.c
@@ -21,6 +21,7 @@
 
 
 #ifdef ENABLE_PROFILING
+#include "pshmem.h"
 
 #pragma weak shmem_ptr = pshmem_ptr
 #define shmem_ptr pshmem_ptr

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -22,6 +22,7 @@
 #include "shmem_collectives.h"
 
 #ifdef ENABLE_PROFILING
+#include "pshmem.h"
 
 #pragma weak shmem_malloc = pshmem_malloc
 #define shmem_malloc pshmem_malloc

--- a/src/synchronization_c.c
+++ b/src/synchronization_c.c
@@ -21,6 +21,7 @@
 #include "shmem_synchronization.h"
 
 #ifdef ENABLE_PROFILING
+#include "pshmem.h"
 
 #pragma weak shmem_quiet = pshmem_quiet
 #define shmem_quiet pshmem_quiet


### PR DESCRIPTION
Include pshmem.h where needed and add missing weak symbols.

Signed-off-by: James Dinan <james.dinan@intel.com>